### PR TITLE
Change drop_nulls default in `convert()` to false

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1180,7 +1180,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
     chunk_columns: Optional[Union[List[str], Tuple[str, ...]]] = None,
     chunk_size: Optional[int] = None,
     infer_common_schema: bool = True,
-    drop_null: bool = True,
+    drop_null: bool = False,
     data_type_cast_map: Optional[Dict[str, str]] = None,
     preset: Optional[str] = "cellprofiler_csv",
     parsl_config: Optional[parsl.Config] = None,
@@ -1225,7 +1225,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             Size of join chunks which is used to limit data size during join ops
         infer_common_schema: bool: (Default value = True)
             Whether to infer a common schema when concatenating sources.
-        drop_null: bool (Default value = True)
+        drop_null: bool (Default value = False)
             Whether to drop nan/null values from results
         preset: str (Default value = "cellprofiler_csv")
             an optional group of presets to use based on common configurations


### PR DESCRIPTION
# Description

Changes the `convert()` default to not drop nulls by default. This is more in-line with expected behavior.

Closes #56

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
