### PR TITLE
Fix test_convert_s3_path_sqlite test failure inconsistencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main, fix-testing]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-testing]
   pull_request:
     branches: [main]
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -553,6 +553,9 @@ def test_convert_s3_path_sqlite(
 ):
     """
     Tests convert with mocked sqlite s3 object storage endpoint
+
+    Note: we use a dedicated tmpdir for work in this test to avoid
+    race conditions with nested pytest fixture post-yield deletions.
     """
 
     tmpdir = tempfile.mkdtemp()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -559,7 +559,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{get_tempdir}/1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -573,7 +573,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path=f"s3://example/nf1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}",
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{get_tempdir}/2/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -588,7 +588,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path="s3://example/nf1/",
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{get_tempdir}/3/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -6,6 +6,8 @@ Tests for CytoTable.convert and related.
 
 import itertools
 import pathlib
+import shutil
+import tempfile
 from shutil import copy
 from typing import Any, Dict, List, Tuple, cast
 
@@ -546,7 +548,6 @@ def test_convert_s3_path_csv(
 
 
 def test_convert_s3_path_sqlite(
-    get_tempdir: str,
     data_dir_cellprofiler_sqlite_nf1: str,
     example_s3_endpoint: str,
 ):
@@ -554,12 +555,14 @@ def test_convert_s3_path_sqlite(
     Tests convert with mocked sqlite s3 object storage endpoint
     """
 
+    tmpdir = tempfile.mkdtemp()
+
     # local sqlite read
     local_cytotable_table = parquet.read_table(
         source=convert(
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=(
-                f"{get_tempdir}/1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{tmpdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -573,7 +576,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path=f"s3://example/nf1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}",
             dest_path=(
-                f"{get_tempdir}/2/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{tmpdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -588,7 +591,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path="s3://example/nf1/",
             dest_path=(
-                f"{get_tempdir}/3/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{tmpdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -612,6 +615,8 @@ def test_convert_s3_path_sqlite(
             [(name, "ascending") for name in s3_cytotable_table_nested.schema.names]
         )
     )
+
+    shutil.rmtree(path=tmpdir, ignore_errors=True)
 
 
 def test_infer_source_group_common_schema(


### PR DESCRIPTION
# Description

The changes in this PR help address test failures found in recent automated test job runs (see [here](https://github.com/cytomining/CytoTable/actions/runs/5682733246/job/15401772592?pr=46), and [here](https://github.com/cytomining/CytoTable/actions/runs/5674349561/job/15377707836?pr=78)). These appear to have been occurring due to temporary directory creation (and related destruction post yield) race conditions with nested pytest fixture usage. Failures are somewhat inconsistent; local and GitHub action based testing sometimes succeed and other times fail. To address this, manual temporary directory creation for `test_convert_s3_path_sqlite` was added to avoid the destination path being removed prior to workflows completing.

Thank you for your review and any thoughts you may have towards changes!

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
