### PR TITLE
Resolve test_convert_s3_path_sqlite test failures with explicit local_cache_dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main, resolve-testing-issue]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, resolve-testing-issue]
   pull_request:
     branches: [main]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def fixture_load_parsl() -> None:
 
 
 # note: we use name here to avoid pylint flagging W0621
-@pytest.fixture(name="get_tempdir")
+@pytest.fixture(name="fx_tempdir")
 def fixture_get_tempdir() -> Generator:
     """
     Provide temporary directory for testing
@@ -79,7 +79,7 @@ def fixture_data_dirs_cytominerdatabase() -> List[str]:
 
 @pytest.fixture(name="cytominerdatabase_sqlite")
 def fixture_cytominerdatabase_sqlite(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dirs_cytominerdatabase: List[str],
 ) -> List[str]:
     """
@@ -90,7 +90,7 @@ def fixture_cytominerdatabase_sqlite(
     for data_dir in data_dirs_cytominerdatabase:
         # example command for reference as subprocess below
         # cytominer-database ingest source_directory sqlite:///backend.sqlite -c ingest_config.ini
-        output_path = f"sqlite:///{get_tempdir}/{pathlib.Path(data_dir).name}.sqlite"
+        output_path = f"sqlite:///{fx_tempdir}/{pathlib.Path(data_dir).name}.sqlite"
 
         # run cytominer-database as command-line call
         subprocess.call(
@@ -111,7 +111,7 @@ def fixture_cytominerdatabase_sqlite(
 
 @pytest.fixture()
 def cytominerdatabase_to_pycytominer_merge_single_cells_parquet(
-    get_tempdir: str,
+    fx_tempdir: str,
     cytominerdatabase_sqlite: List[str],
 ) -> List[str]:
     """
@@ -128,7 +128,7 @@ def cytominerdatabase_to_pycytominer_merge_single_cells_parquet(
                 strata=["Metadata_Well"],
                 image_cols=["TableNumber", "ImageNumber"],
             ).merge_single_cells(
-                sc_output_file=f"{get_tempdir}/{pathlib.Path(sqlite_file).name}.parquet",
+                sc_output_file=f"{fx_tempdir}/{pathlib.Path(sqlite_file).name}.parquet",
                 output_type="parquet",
                 join_on=["Image_Metadata_Well"],
             )
@@ -200,7 +200,7 @@ def fixture_example_tables() -> Tuple[pa.Table, ...]:
 
 @pytest.fixture(name="example_local_sources")
 def fixture_example_local_sources(
-    get_tempdir: str,
+    fx_tempdir: str,
     example_tables: Tuple[pa.Table, ...],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
@@ -213,57 +213,57 @@ def fixture_example_local_sources(
         ["image", "cytoplasm", "cells", "nuclei", "nuclei"],
     ):
         # build paths for output to land
-        pathlib.Path(f"{get_tempdir}/example/{number}").mkdir(
+        pathlib.Path(f"{fx_tempdir}/example/{number}").mkdir(
             parents=True, exist_ok=True
         )
-        pathlib.Path(f"{get_tempdir}/example_dest/{name}/{number}").mkdir(
+        pathlib.Path(f"{fx_tempdir}/example_dest/{name}/{number}").mkdir(
             parents=True, exist_ok=True
         )
         # write example input
-        csv.write_csv(table, f"{get_tempdir}/example/{number}/{name}.csv")
+        csv.write_csv(table, f"{fx_tempdir}/example/{number}/{name}.csv")
         # write example output
         parquet.write_table(
-            table, f"{get_tempdir}/example_dest/{name}/{number}/{name}.parquet"
+            table, f"{fx_tempdir}/example_dest/{name}/{number}/{name}.parquet"
         )
 
     return {
         "image.csv": [
             {
-                "source_path": pathlib.Path(f"{get_tempdir}/example/0/image.csv"),
+                "source_path": pathlib.Path(f"{fx_tempdir}/example/0/image.csv"),
                 "table": [
-                    pathlib.Path(f"{get_tempdir}/example_dest/image/0/image.parquet")
+                    pathlib.Path(f"{fx_tempdir}/example_dest/image/0/image.parquet")
                 ],
             },
         ],
         "cytoplasm.csv": [
             {
-                "source_path": pathlib.Path(f"{get_tempdir}/example/1/cytoplasm.csv"),
+                "source_path": pathlib.Path(f"{fx_tempdir}/example/1/cytoplasm.csv"),
                 "table": [
                     pathlib.Path(
-                        f"{get_tempdir}/example_dest/cytoplasm/1/cytoplasm.parquet"
+                        f"{fx_tempdir}/example_dest/cytoplasm/1/cytoplasm.parquet"
                     )
                 ],
             }
         ],
         "cells.csv": [
             {
-                "source_path": pathlib.Path(f"{get_tempdir}/example/2/cells.csv"),
+                "source_path": pathlib.Path(f"{fx_tempdir}/example/2/cells.csv"),
                 "table": [
-                    pathlib.Path(f"{get_tempdir}/example_dest/cells/2/cells.parquet")
+                    pathlib.Path(f"{fx_tempdir}/example_dest/cells/2/cells.parquet")
                 ],
             }
         ],
         "nuclei.csv": [
             {
-                "source_path": pathlib.Path(f"{get_tempdir}/example/3/nuclei.csv"),
+                "source_path": pathlib.Path(f"{fx_tempdir}/example/3/nuclei.csv"),
                 "table": [
-                    pathlib.Path(f"{get_tempdir}/example_dest/nuclei/3/nuclei.parquet")
+                    pathlib.Path(f"{fx_tempdir}/example_dest/nuclei/3/nuclei.parquet")
                 ],
             },
             {
-                "source_path": pathlib.Path(f"{get_tempdir}/example/4/nuclei.csv"),
+                "source_path": pathlib.Path(f"{fx_tempdir}/example/4/nuclei.csv"),
                 "table": [
-                    pathlib.Path(f"{get_tempdir}/example_dest/nuclei/4/nuclei.parquet")
+                    pathlib.Path(f"{fx_tempdir}/example_dest/nuclei/4/nuclei.parquet")
                 ],
             },
         ],
@@ -493,7 +493,7 @@ def example_s3_endpoint(
 
 @pytest.fixture()
 def example_sqlite_mixed_types_database(
-    get_tempdir: str,
+    fx_tempdir: str,
 ) -> Generator:
     """
     Creates a database which includes mixed type columns
@@ -501,7 +501,7 @@ def example_sqlite_mixed_types_database(
     """
 
     # create a temporary sqlite connection
-    filepath = f"{get_tempdir}/example_mixed_types.sqlite"
+    filepath = f"{fx_tempdir}/example_mixed_types.sqlite"
 
     # statements for creating database with simple structure
     create_stmts = [

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -6,8 +6,6 @@ Tests for CytoTable.convert and related.
 
 import itertools
 import pathlib
-import shutil
-import tempfile
 from shutil import copy
 from typing import Any, Dict, List, Tuple, cast
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -595,7 +595,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path="s3://example/nf1/",
             dest_path=(
-                f"{get_tmpdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -59,13 +59,13 @@ def test_config():
         ) == sorted(config_preset.keys())
 
 
-def test_get_source_filepaths(get_tempdir: str, data_dir_cellprofiler: str):
+def test_get_source_filepaths(fx_tempdir: str, data_dir_cellprofiler: str):
     """
     Tests _get_source_filepaths
     """
 
     # test that no sources raises an exception
-    empty_dir = pathlib.Path(f"{get_tempdir}/temp")
+    empty_dir = pathlib.Path(f"{fx_tempdir}/temp")
     empty_dir.mkdir(parents=True, exist_ok=True)
     with pytest.raises(Exception):
         single_dir_result = _get_source_filepaths(
@@ -104,13 +104,13 @@ def test_get_source_filepaths(get_tempdir: str, data_dir_cellprofiler: str):
     assert len(set(single_dir_result.keys())) == 4
 
 
-def test_prepend_column_name(get_tempdir: str):
+def test_prepend_column_name(fx_tempdir: str):
     """
     Tests _prepend_column_name
     """
 
     # example cytoplasm csv table run
-    prepend_testpath_1 = f"{get_tempdir}/prepend_testpath_1.parquet"
+    prepend_testpath_1 = f"{fx_tempdir}/prepend_testpath_1.parquet"
     parquet.write_table(
         table=pa.Table.from_pydict(
             {
@@ -148,7 +148,7 @@ def test_prepend_column_name(get_tempdir: str):
     ]
 
     # example cells sqlite table run
-    repend_testpath_2 = f"{get_tempdir}/prepend_testpath_2.parquet"
+    repend_testpath_2 = f"{fx_tempdir}/prepend_testpath_2.parquet"
     parquet.write_table(
         table=pa.Table.from_pydict(
             {
@@ -184,7 +184,7 @@ def test_prepend_column_name(get_tempdir: str):
 
 
 def test_concat_source_group(
-    get_tempdir: str,
+    fx_tempdir: str,
     example_tables: Tuple[pa.Table, ...],
     example_local_sources: Dict[str, List[Dict[str, Any]]],
 ):
@@ -200,7 +200,7 @@ def test_concat_source_group(
     result = _concat_source_group(
         source_group_name="nuclei",
         source_group=example_local_sources["nuclei.csv"],
-        dest_path=get_tempdir,
+        dest_path=fx_tempdir,
         common_schema=table_nuclei_1.schema,
     ).result()
     assert len(result) == 1
@@ -216,13 +216,13 @@ def test_concat_source_group(
             "color": pa.array(["blue", "red", "green", "orange"]),
         }
     )
-    pathlib.Path(f"{get_tempdir}/example/5").mkdir(parents=True, exist_ok=True)
-    csv.write_csv(mismatching_table, f"{get_tempdir}/example/5/nuclei.csv")
-    parquet.write_table(mismatching_table, f"{get_tempdir}/example/5.nuclei.parquet")
+    pathlib.Path(f"{fx_tempdir}/example/5").mkdir(parents=True, exist_ok=True)
+    csv.write_csv(mismatching_table, f"{fx_tempdir}/example/5/nuclei.csv")
+    parquet.write_table(mismatching_table, f"{fx_tempdir}/example/5.nuclei.parquet")
     example_local_sources["nuclei.csv"].append(
         {
-            "source_path": pathlib.Path(f"{get_tempdir}/example/5/nuclei.csv"),
-            "destination_path": pathlib.Path(f"{get_tempdir}/example/5.nuclei.parquet"),
+            "source_path": pathlib.Path(f"{fx_tempdir}/example/5/nuclei.csv"),
+            "destination_path": pathlib.Path(f"{fx_tempdir}/example/5.nuclei.parquet"),
         }
     )
 
@@ -230,17 +230,17 @@ def test_concat_source_group(
         _concat_source_group(
             source_group_name="nuclei",
             source_group=example_local_sources["nuclei.csv"],
-            dest_path=get_tempdir,
+            dest_path=fx_tempdir,
         ).result()
 
 
-def test_get_join_chunks(get_tempdir: str):
+def test_get_join_chunks(fx_tempdir: str):
     """
     Tests _get_join_chunks
     """
 
     # form test path
-    test_path = f"{get_tempdir}/merge_chunks_test.parquet"
+    test_path = f"{fx_tempdir}/merge_chunks_test.parquet"
 
     # write test data to file
     parquet.write_table(
@@ -272,15 +272,15 @@ def test_get_join_chunks(get_tempdir: str):
     ) == {"id1", "id2"}
 
 
-def test_join_source_chunk(get_tempdir: str):
+def test_join_source_chunk(fx_tempdir: str):
     """
     Tests _get_join_chunks
     """
 
     # form test path a
-    test_path_a = f"{get_tempdir}/example_a_merged.parquet"
+    test_path_a = f"{fx_tempdir}/example_a_merged.parquet"
     # form test path b
-    test_path_b = f"{get_tempdir}/example_b_merged.parquet"
+    test_path_b = f"{fx_tempdir}/example_b_merged.parquet"
 
     # write test data to file
     parquet.write_table(
@@ -310,11 +310,11 @@ def test_join_source_chunk(get_tempdir: str):
             "example_a": [{"table": [test_path_a]}],
             "example_b": [{"table": [test_path_b]}],
         },
-        dest_path=f"{get_tempdir}/destination.parquet",
+        dest_path=f"{fx_tempdir}/destination.parquet",
         joins=f"""
             SELECT *
-            FROM read_parquet('{get_tempdir}/example_a_merged.parquet') as example_a
-            JOIN read_parquet('{get_tempdir}/example_b_merged.parquet') as example_b ON
+            FROM read_parquet('{fx_tempdir}/example_a_merged.parquet') as example_a
+            JOIN read_parquet('{fx_tempdir}/example_b_merged.parquet') as example_b ON
                 example_b.id1 = example_a.id1
                 AND example_b.id2 = example_a.id2
         """,
@@ -338,19 +338,19 @@ def test_join_source_chunk(get_tempdir: str):
     )
 
 
-def test_concat_join_sources(get_tempdir: str):
+def test_concat_join_sources(fx_tempdir: str):
     """
     Tests _concat_join_sources
     """
 
     # create a test dir
-    pathlib.Path(f"{get_tempdir}/concat_join/").mkdir(exist_ok=True)
+    pathlib.Path(f"{fx_tempdir}/concat_join/").mkdir(exist_ok=True)
 
     # form test paths
-    test_path_a = f"{get_tempdir}/concat_join/join_chunks_test_a.parquet"
-    test_path_b = f"{get_tempdir}/concat_join/join_chunks_test_b.parquet"
-    test_path_a_join_chunk = f"{get_tempdir}/join_chunks_test_a.parquet"
-    test_path_b_join_chunk = f"{get_tempdir}/join_chunks_test_b.parquet"
+    test_path_a = f"{fx_tempdir}/concat_join/join_chunks_test_a.parquet"
+    test_path_b = f"{fx_tempdir}/concat_join/join_chunks_test_b.parquet"
+    test_path_a_join_chunk = f"{fx_tempdir}/join_chunks_test_a.parquet"
+    test_path_b_join_chunk = f"{fx_tempdir}/join_chunks_test_b.parquet"
 
     # form test data
     test_table_a = pa.Table.from_pydict(
@@ -400,12 +400,12 @@ def test_concat_join_sources(get_tempdir: str):
     copy(test_path_a, test_path_a_join_chunk)
     copy(test_path_b, test_path_b_join_chunk)
 
-    pathlib.Path(f"{get_tempdir}/test_concat_join_sources").mkdir(
+    pathlib.Path(f"{fx_tempdir}/test_concat_join_sources").mkdir(
         parents=True, exist_ok=True
     )
 
     result = _concat_join_sources(
-        dest_path=f"{get_tempdir}/test_concat_join_sources/example_concat_join.parquet",
+        dest_path=f"{fx_tempdir}/test_concat_join_sources/example_concat_join.parquet",
         join_sources=[test_path_a_join_chunk, test_path_b_join_chunk],
         sources={
             "join_chunks_test_a.parquet": [{"table": [test_path_a]}],
@@ -447,7 +447,7 @@ def test_infer_source_datatype():
 
 
 def test_to_parquet(
-    get_tempdir: str, example_local_sources: Dict[str, List[Dict[str, Any]]]
+    fx_tempdir: str, example_local_sources: Dict[str, List[Dict[str, Any]]]
 ):
     """
     Tests _to_parquet
@@ -464,7 +464,7 @@ def test_to_parquet(
             source_path=str(
                 example_local_sources["image.csv"][0]["source_path"].parent
             ),
-            dest_path=get_tempdir,
+            dest_path=fx_tempdir,
             source_datatype=None,
             compartments=["cytoplasm", "cells", "nuclei"],
             metadata=["image"],
@@ -500,7 +500,7 @@ def test_to_parquet(
 
 
 def test_convert_s3_path_csv(
-    get_tempdir: str,
+    fx_tempdir: str,
     example_local_sources: Dict[str, List[Dict[str, Any]]],
     example_s3_endpoint: str,
 ):
@@ -510,7 +510,7 @@ def test_convert_s3_path_csv(
 
     multi_dir_nonconcat_s3_result = convert(
         source_path="s3://example/",
-        dest_path=f"{get_tempdir}/s3_test",
+        dest_path=f"{fx_tempdir}/s3_test",
         dest_datatype="parquet",
         concat=False,
         join=False,
@@ -546,7 +546,7 @@ def test_convert_s3_path_csv(
 
 
 def test_convert_s3_path_sqlite(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dir_cellprofiler_sqlite_nf1: str,
     example_s3_endpoint: str,
 ):
@@ -562,7 +562,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -576,7 +576,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path=f"s3://example/nf1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}",
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -586,7 +586,7 @@ def test_convert_s3_path_sqlite(
             # use explicit cache to avoid temp cache removal / overlaps with
             # sequential s3 SQLite files. See below for more information
             # https://cloudpathlib.drivendata.org/stable/caching/#automatically
-            local_cache_dir=f"{get_tempdir}/sqlite_s3_cache/1",
+            local_cache_dir=f"{fx_tempdir}/sqlite_s3_cache/1",
         )
     )
 
@@ -595,7 +595,7 @@ def test_convert_s3_path_sqlite(
         source=convert(
             source_path="s3://example/nf1/",
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -605,7 +605,7 @@ def test_convert_s3_path_sqlite(
             # use explicit cache to avoid temp cache removal / overlaps with
             # sequential s3 SQLite files. See below for more information
             # https://cloudpathlib.drivendata.org/stable/caching/#automatically
-            local_cache_dir=f"{get_tempdir}/sqlite_s3_cache/2",
+            local_cache_dir=f"{fx_tempdir}/sqlite_s3_cache/2",
         )
     )
 
@@ -642,7 +642,7 @@ def test_infer_source_group_common_schema(
 
 
 def test_convert_cytominerdatabase_csv(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dirs_cytominerdatabase: List[str],
     cytominerdatabase_to_pycytominer_merge_single_cells_parquet: List[str],
 ):
@@ -680,7 +680,7 @@ def test_convert_cytominerdatabase_csv(
             source=convert(
                 source_path=cytominerdatabase_dir,
                 dest_path=(
-                    f"{get_tempdir}/{pathlib.Path(cytominerdatabase_dir).name}.test_table.parquet"
+                    f"{fx_tempdir}/{pathlib.Path(cytominerdatabase_dir).name}.test_table.parquet"
                 ),
                 dest_datatype="parquet",
                 source_datatype="csv",
@@ -696,7 +696,7 @@ def test_convert_cytominerdatabase_csv(
 
 
 def test_convert_cellprofiler_sqlite(
-    get_tempdir: str, data_dir_cellprofiler: str, cellprofiler_merged_nf1data: pa.Table
+    fx_tempdir: str, data_dir_cellprofiler: str, cellprofiler_merged_nf1data: pa.Table
 ):
     """
     Tests convert with cellprofiler sqlite exports
@@ -709,7 +709,7 @@ def test_convert_cellprofiler_sqlite(
             source_path=(
                 f"{data_dir_cellprofiler}/NF1_SchwannCell_data/all_cellprofiler.sqlite"
             ),
-            dest_path=f"{get_tempdir}/NF1_data.parquet",
+            dest_path=f"{fx_tempdir}/NF1_data.parquet",
             dest_datatype="parquet",
             source_datatype="sqlite",
             preset="cellprofiler_sqlite",
@@ -730,7 +730,7 @@ def test_convert_cellprofiler_sqlite(
 
 
 def test_convert_cellprofiler_csv(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dir_cellprofiler: str,
     cellprofiler_merged_examplehuman: pa.Table,
 ):
@@ -745,7 +745,7 @@ def test_convert_cellprofiler_csv(
     with pytest.raises(Exception):
         convert(
             source_path=f"{data_dir_cellprofiler}/ExampleHuman",
-            dest_path=f"{get_tempdir}/ExampleHuman",
+            dest_path=f"{fx_tempdir}/ExampleHuman",
             dest_datatype="parquet",
             source_datatype="csv",
             compartments=[],
@@ -756,7 +756,7 @@ def test_convert_cellprofiler_csv(
     test_result = parquet.read_table(
         convert(
             source_path=f"{data_dir_cellprofiler}/ExampleHuman",
-            dest_path=f"{get_tempdir}/ExampleHuman",
+            dest_path=f"{fx_tempdir}/ExampleHuman",
             dest_datatype="parquet",
             source_datatype="csv",
             preset="cellprofiler_csv",
@@ -777,14 +777,14 @@ def test_convert_cellprofiler_csv(
 
 
 def test_cast_data_types(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dir_cellprofiler_sqlite_nf1: str,
 ):
     """
     Tests _cast_data_types to ensure data types are casted as expected
     """
 
-    test_dir = f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+    test_dir = f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
     # default data types
     convert(
         source_path=data_dir_cellprofiler_sqlite_nf1,
@@ -874,7 +874,7 @@ def test_cast_data_types(
 
 
 def test_convert_cellprofiler_sqlite_pycytominer_merge(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dir_cellprofiler_sqlite_nf1: str,
 ):
     """
@@ -904,7 +904,7 @@ def test_convert_cellprofiler_sqlite_pycytominer_merge(
             # and receive parquet filepath
         ).merge_single_cells(
             sc_output_file=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".pycytominer.parquet"
             ),
             output_type="parquet",
@@ -920,7 +920,7 @@ def test_convert_cellprofiler_sqlite_pycytominer_merge(
         source=convert(
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=(
-                f"{get_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
+                f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
                 ".cytotable.parquet"
             ),
             dest_datatype="parquet",
@@ -949,13 +949,13 @@ def test_convert_cellprofiler_sqlite_pycytominer_merge(
 
 
 def test_sqlite_mixed_type_query_to_parquet(
-    get_tempdir: str, example_sqlite_mixed_types_database: str
+    fx_tempdir: str, example_sqlite_mixed_types_database: str
 ):
     """
     Testing _sqlite_mixed_type_query_to_parquet
     """
 
-    result_filepath = f"{get_tempdir}/example_mixed_types_tbl_a.parquet"
+    result_filepath = f"{fx_tempdir}/example_mixed_types_tbl_a.parquet"
     table_name = "tbl_a"
 
     try:
@@ -1005,7 +1005,7 @@ def test_sqlite_mixed_type_query_to_parquet(
 
 
 def test_convert_hte_cellprofiler_csv(
-    get_tempdir: str,
+    fx_tempdir: str,
     data_dir_cellprofiler: str,
     cellprofiler_merged_examplehuman: pa.Table,
 ):
@@ -1037,7 +1037,7 @@ def test_convert_hte_cellprofiler_csv(
     test_result = parquet.read_table(
         convert(
             source_path=f"{data_dir_cellprofiler}/ExampleHuman",
-            dest_path=f"{get_tempdir}/ExampleHuman",
+            dest_path=f"{fx_tempdir}/ExampleHuman",
             dest_datatype="parquet",
             source_datatype="csv",
             preset="cellprofiler_csv",


### PR DESCRIPTION
# Description

This PR seeks to address #81 where tests periodically fail with `test_convert_s3_path_sqlite` (see issue for greater specificity on the patterns associated). Initially I made the mistake of believing this was caused due to nested Pytest fixture behavior with temporary directories supplied to tests (see PR #79). This PR reverts those changes and adds different ones to prevent the same tests failures from persisting.

I believe this test is failing due to [Cloudpathlib's default temporary cache behavior (`"tmp_dir"`)](https://cloudpathlib.drivendata.org/stable/caching/#automatically). Two `convert` calls are made, both using the default temporary cache location to store the SQLite file locally. When the first `convert` completes, the second `convert` seems to begin the process of reading from the same cache location which seems to persist for a short time after the first `convert` completes. Eventually, the temporary directory supplied from Cloudpathlib is removed while the second `convert` is running. I hypothesize that tests only periodically fail due to how quickly they can generally run, with Python 3.8 (where the issue often occurs) missing performance improvements available to Python 3.9 and 3.10.

Detection of the missing source data file has gone undetected due to a missing `raise` for DuckDB exceptions when extracting data. A `raise` is added for these exceptions with #82 (where linting demonstrated a need through `_get_table_columns_and_types` changes during development). A Github Actions job run which exhibits the error with a `raise` [may be found here](https://github.com/d33bs/CytoTable/actions/runs/5728135298/job/15522026550). Full logs are attached here [here](https://github.com/cytomining/CytoTable/files/12234217/1_run_tests.3.8.txt) for later reference in case they're purged.

After adding an explicit `local_cache_dir` value for these test runs of `convert` within test_convert_s3_path_sqlite I no longer have witnessed the issue occurring.

Thanks in advance for any thoughts and feedback on this PR!

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
