### PR TITLE
Add SQLite affinity type synonym matching for _sqlite_mixed_type_query_to_parquet

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,7 +511,14 @@ def example_sqlite_mixed_types_database(
         col_integer INTEGER NOT NULL
         ,col_text TEXT
         ,col_blob BLOB
-        ,col_real REAL
+        /* note: here we use DOUBLE instead of REAL
+        to help test scenarios where the column type
+        does not align with values SQLite yields from
+        SQL function `typeof()`. In this example,
+        SQLite will have a column with type of DOUBLE
+        and floating-point values in that column
+        will have a type of REAL. */
+        ,col_real DOUBLE
         );
         """,
     ]


### PR DESCRIPTION
# Description

The PR adds the capability for CytoTable to properly associate SQLite column type with actual value types (which have the possibility of mismatched names based on SQLite design) when dealing with exception cases where data value types do not match the column type in `_sqlite_mixed_type_query_to_parquet`. The logic behind how SQLite operates with regards to column and value typing may be [found here](https://www.sqlite.org/datatype3.html#affinity_name_examples). This change helps further prepare the work found in #46, where mixed SQLite data type handling is required.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
