### PR TITLE
Move to PyArrow parquet writer for data extraction

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -308,9 +308,9 @@ def _source_chunk_to_parquet(
 
     result_filepath = f"{result_filepath_base}-{offset}.parquet"
 
-    # attempt to read the data to parquet from duckdb
-    # with exception handling to read mixed-type data
-    # using sqlite3 and special utility function
+    # Attempt to read the data to parquet file
+    # using duckdb for extraction and pyarrow for
+    # writing data to a parquet file.
     try:
         # read data with chunk size + offset
         # and export to parquet
@@ -325,6 +325,8 @@ def _source_chunk_to_parquet(
             .arrow(),
             where=result_filepath,
         )
+    # Include exception handling to read mixed-type data
+    # using sqlite3 and special utility function.
     except duckdb.Error as e:
         # if we see a mismatched type error
         # run a more nuanced query through sqlite
@@ -334,6 +336,9 @@ def _source_chunk_to_parquet(
             and str(AnyPath(source["source_path"]).suffix).lower() == ".sqlite"
         ):
             parquet.write_table(
+                # here we use sqlite instead of duckdb to extract
+                # data for special cases where column and value types
+                # may not align (which is valid functionality in SQLite).
                 table=_sqlite_mixed_type_query_to_parquet(
                     source_path=str(source["source_path"]),
                     table_name=str(source["table_name"]),


### PR DESCRIPTION
# Description

This PR seeks to address concerns which were raised by @jenna-tomkinson via #85 and #86. There appears to be a challenge in extracting certain data from SQLite through DuckDB and writing it directly to a file with DuckDB. This change updates CytoTable to use DuckDB for extraction (remains the same) and PyArrow's Parquet table writer for writing to file (updated). In testing this functionality with currently non-public datasets I was able to observe the correct number of unique ImageNumber keys when using only an Image and Nuclei table with SQL inner joins (as described in the issues).

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
