### PR TITLE
Add exception on existing `dest_path` to avoid unsafe operation

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1035,7 +1035,10 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
             Note: may be local or remote object-storage
             location using convention "s3://..." or similar.
         dest_path: str:
-            Path to write files to.
+            Path to write files to. This path will be used for
+            intermediary data work and must be a new file or directory path.
+            This parameter will result in a directory on `join=False`.
+            This parameter will result in a single file on `join=True`.
             Note: this may only be a local path.
         source_datatype: Optional[str]: (Default value = None)
             Source datatype to focus on during conversion.
@@ -1290,13 +1293,13 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             Note: may be local or remote object-storage location
             using convention "s3://..." or similar.
         dest_path: str:
-            Path to write files to.
-            Note: this may only be a local path.
-        dest_datatype: Literal["parquet"]:
-            Destination datatype to write to. This path will be used for
+            Path to write files to. This path will be used for
             intermediary data work and must be a new file or directory path.
             This parameter will result in a directory on `join=False`.
             This parameter will result in a single file on `join=True`.
+            Note: this may only be a local path.
+        dest_datatype: Literal["parquet"]:
+            Destination datatype to write to.
         source_datatype: Optional[str]:  (Default value = None)
             Source datatype to focus on during conversion.
         metadata: Union[List[str], Tuple[str, ...]]:

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1377,7 +1377,10 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
     # to avoid removing existing data or unrelated data removal.
     if _expand_path(dest_path).exists():
         raise CytoTableException(
-            "An existing file or directory was provided as a dest_path. Please use a new path for this parameter."
+            (
+                "An existing file or directory was provided as dest_path: "
+                f"'{dest_path}'. Please use a new path for this parameter."
+            )
         )
 
     # attempt to load parsl configuration if we didn't already load one

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -557,10 +557,6 @@ def _concat_source_group(
     from cytotable.exceptions import SchemaException
     from cytotable.utils import CYTOTABLE_ARROW_USE_MEMORY_MAPPING
 
-    # check whether we already have a file as dest_path
-    if pathlib.Path(dest_path).is_file():
-        pathlib.Path(dest_path).unlink(missing_ok=True)
-
     # build a result placeholder
     concatted: List[Dict[str, Any]] = [
         {
@@ -857,9 +853,6 @@ def _concat_join_sources(
     if pathlib.Path(dest_path).is_dir():
         shutil.rmtree(path=dest_path)
 
-    # also remove any pre-existing files which may already be at file destination
-    pathlib.Path(dest_path).unlink(missing_ok=True)
-
     # write the concatted result as a parquet file
     parquet.write_table(
         table=pa.concat_tables(
@@ -1078,8 +1071,6 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
             result.
     """
 
-    import pathlib
-
     from cytotable.convert import (
         _concat_join_sources,
         _concat_source_group,
@@ -1101,10 +1092,6 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
         targets=list(metadata) + list(compartments),
         **kwargs,
     ).result()
-
-    # if we already have a file in dest_path, remove it
-    if pathlib.Path(dest_path).is_file():
-        pathlib.Path(dest_path).unlink()
 
     # expand the destination path
     expanded_dest_path = _expand_path(path=dest_path)

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -495,7 +495,7 @@ def _prepend_column_name(
 def _concat_source_group(
     source_group_name: str,
     source_group: List[Dict[str, Any]],
-    dest_path: str = ".",
+    dest_path: str,
     common_schema: Optional[List[Tuple[str, str]]] = None,
 ) -> List[Dict[str, Any]]:
     """

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -10,6 +10,9 @@ CytoTable converts this data to Parquet from local or object-storage based locat
 Files with similar names nested within sub-folders will be concatenated by default (appended to the end of each data file) together and used to create a single Parquet file per compartment.
 For example: if we have `folder/subfolder_a/cells.csv` and `folder/subfolder_b/cells.csv`, using `convert(source_path="folder", ...)` will result in `folder.cells.parquet` (unless `concat=False`).
 
+Note: The `dest_path` parameter (`convert(dest_path="")`) will be used for intermediary data work and must be a new file or directory path.
+This path will result directory output on `join=False` and a single file output on `join=True`.
+
 For example, see below:
 
 ```python
@@ -17,9 +20,9 @@ from cytotable import convert
 
 # using a local path with cellprofiler csv presets
 convert(
-    source_path="./tests/data/cellprofiler/csv_single",
+    source_path="./tests/data/cellprofiler/ExampleHuman",
     source_datatype="csv",
-    dest_path=".",
+    dest_path="ExampleHuman.parquet",
     dest_datatype="parquet",
     preset="cellprofiler_csv",
 )
@@ -29,7 +32,7 @@ convert(
 convert(
     source_path="s3://s3path",
     source_datatype="csv",
-    dest_path=".",
+    dest_path="s3_local_result",
     dest_datatype="parquet",
     concat=True,
     preset="cellprofiler_csv",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -98,6 +98,24 @@ def test_existing_dest_path(fx_tempdir: str, data_dir_cellprofiler_sqlite_nf1: s
             preset="cellprofiler_sqlite_pycytominer",
         )
 
+    # test raise with $HOME as dest_path
+    with pytest.raises(CytoTableException):
+        convert(
+            source_path=data_dir_cellprofiler_sqlite_nf1,
+            dest_path="$HOME",
+            dest_datatype="parquet",
+            preset="cellprofiler_sqlite_pycytominer",
+        )
+
+    # test raise with "." as dest_path
+    with pytest.raises(CytoTableException):
+        convert(
+            source_path=data_dir_cellprofiler_sqlite_nf1,
+            dest_path=".",
+            dest_datatype="parquet",
+            preset="cellprofiler_sqlite_pycytominer",
+        )
+
 
 def test_extend_path(fx_tempdir: str):
     """

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -33,6 +33,7 @@ from cytotable.convert import (
     _to_parquet,
     convert,
 )
+from cytotable.exceptions import CytoTableException
 from cytotable.presets import config
 from cytotable.sources import _get_source_filepaths, _infer_source_datatype
 from cytotable.utils import (
@@ -61,6 +62,41 @@ def test_config():
                 "CONFIG_SOURCE_VERSION",
             ]
         ) == sorted(config_preset.keys())
+
+
+def test_existing_dest_path(fx_tempdir: str, data_dir_cellprofiler_sqlite_nf1: str):
+    """
+    Tests running cytotable.convert with existing dest_path
+    where we expect a raised exception to avoid data loss.
+    """
+
+    # locations for test dir and file
+    test_dir = f"{fx_tempdir}/existing_dir"
+    test_file = f"{fx_tempdir}/existing_file"
+
+    # Create an empty directory
+    pathlib.Path(test_dir).mkdir()
+
+    # Create an empty file
+    pathlib.Path(test_file).touch()
+
+    # test raise with existing dir as dest_path
+    with pytest.raises(CytoTableException):
+        convert(
+            source_path=data_dir_cellprofiler_sqlite_nf1,
+            dest_path=test_dir,
+            dest_datatype="parquet",
+            preset="cellprofiler_sqlite_pycytominer",
+        )
+
+    # test raise with existing file as dest_path
+    with pytest.raises(CytoTableException):
+        convert(
+            source_path=data_dir_cellprofiler_sqlite_nf1,
+            dest_path=test_file,
+            dest_datatype="parquet",
+            preset="cellprofiler_sqlite_pycytominer",
+        )
 
 
 def test_extend_path(fx_tempdir: str):
@@ -589,7 +625,7 @@ def test_convert_s3_path_sqlite(
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=(
                 f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
-                ".cytotable.parquet"
+                ".cytotable.local.parquet"
             ),
             dest_datatype="parquet",
             chunk_size=100,
@@ -603,7 +639,7 @@ def test_convert_s3_path_sqlite(
             source_path=f"s3://example/nf1/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}",
             dest_path=(
                 f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
-                ".cytotable.parquet"
+                ".cytotable.mocks3.direct.parquet"
             ),
             dest_datatype="parquet",
             chunk_size=100,
@@ -622,7 +658,7 @@ def test_convert_s3_path_sqlite(
             source_path="s3://example/nf1/",
             dest_path=(
                 f"{fx_tempdir}/{pathlib.Path(data_dir_cellprofiler_sqlite_nf1).name}"
-                ".cytotable.parquet"
+                ".cytotable.mocks3.nested.parquet"
             ),
             dest_datatype="parquet",
             chunk_size=100,
@@ -771,7 +807,7 @@ def test_convert_cellprofiler_csv(
     with pytest.raises(Exception):
         convert(
             source_path=f"{data_dir_cellprofiler}/ExampleHuman",
-            dest_path=f"{fx_tempdir}/ExampleHuman",
+            dest_path=f"{fx_tempdir}/ExampleHuman_result_1",
             dest_datatype="parquet",
             source_datatype="csv",
             compartments=[],
@@ -782,7 +818,7 @@ def test_convert_cellprofiler_csv(
     test_result = parquet.read_table(
         convert(
             source_path=f"{data_dir_cellprofiler}/ExampleHuman",
-            dest_path=f"{fx_tempdir}/ExampleHuman",
+            dest_path=f"{fx_tempdir}/ExampleHuman_result_2",
             dest_datatype="parquet",
             source_datatype="csv",
             preset="cellprofiler_csv",
@@ -1034,7 +1070,7 @@ def test_sqlite_mixed_type_query_to_parquet(
     # run full convert on mixed type database
     result = convert(
         source_path=example_sqlite_mixed_types_database,
-        dest_path=result_filepath,
+        dest_path=f"{fx_tempdir}/example_mixed_types_tbl_a.cytotable.parquet",
         dest_datatype="parquet",
         source_datatype="sqlite",
         compartments=[table_name],

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -86,6 +86,7 @@ def test_existing_dest_path(fx_tempdir: str, data_dir_cellprofiler_sqlite_nf1: s
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=test_dir,
             dest_datatype="parquet",
+            join=False,
             preset="cellprofiler_sqlite_pycytominer",
         )
 
@@ -95,6 +96,7 @@ def test_existing_dest_path(fx_tempdir: str, data_dir_cellprofiler_sqlite_nf1: s
             source_path=data_dir_cellprofiler_sqlite_nf1,
             dest_path=test_file,
             dest_datatype="parquet",
+            join=True,
             preset="cellprofiler_sqlite_pycytominer",
         )
 


### PR DESCRIPTION
# Description

This PR adds a check at the beginning of `cytotable.convert()` to ensure `dest_path` does not exist as a file or directory to help avoid data loss. Documentation was also updated to avoid unsafe and no longer valid `dest_path="."` references.

Many thanks to @sbamin for raising and suggestions in #102 . 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
