### PR TITLE
Use Parsl ConfigurationError for detecting existing Parsl configurations

### DIFF
--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -111,7 +111,7 @@ def _parsl_loaded() -> bool:
     except ConfigurationError as pce:
         # if we detect a Parsl ConfigurationError that states we need to load config
         # return false to indicate parsl config has not yet been loaded.
-        if str(pce) == "Must first load config":
+        if pce.args[0] == "Must first load config":
             return False
 
         # otherwise we raise other ConfigurationError's

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -14,6 +14,7 @@ from cloudpathlib import AnyPath, CloudPath
 from cloudpathlib.exceptions import InvalidPrefixError
 from parsl.app.app import AppBase
 from parsl.config import Config
+from parsl.errors import ConfigurationError
 from parsl.executors import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
@@ -107,13 +108,13 @@ def _parsl_loaded() -> bool:
     try:
         # try to reference Parsl dataflowkernel
         parsl.dfk()
-    except RuntimeError as rte:
-        # if we detect a runtime error that states we need to load config
+    except ConfigurationError as pce:
+        # if we detect a Parsl ConfigurationError that states we need to load config
         # return false to indicate parsl config has not yet been loaded.
-        if str(rte) == "Must first load config":
+        if str(pce) == "Must first load config":
             return False
 
-        # otherwise we raise other RuntimeError's
+        # otherwise we raise other ConfigurationError's
         else:
             raise
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1967,13 +1967,13 @@ files = [
 
 [[package]]
 name = "parsl"
-version = "2023.9.11"
+version = "2023.9.18"
 description = "Simple data dependent workflows in Python"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "parsl-2023.9.11-py3-none-any.whl", hash = "sha256:167e9d37d70afab7b9a9aba1bee3d1c42c10592726084d7685b08c71881ce8d8"},
-    {file = "parsl-2023.9.11.tar.gz", hash = "sha256:8c56ddbeb9e95d5bc2254b5dfc78227f70a73d36665799b1d3f27cb84599d6dd"},
+    {file = "parsl-2023.9.18-py3-none-any.whl", hash = "sha256:e12b3ff2c57b7a15ce5181cfa7019fea98b7a5c8348d7046a98585a2aca09914"},
+    {file = "parsl-2023.9.18.tar.gz", hash = "sha256:b8a530358022dd76ebd4d1bbdf6ae8ea31df67fc3c825affe08a207c483d7ff1"},
 ]
 
 [package.dependencies]
@@ -3543,4 +3543,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "7064316c8663a5aee617493b6da6c9e717d2954814d954a03bc97a7224e5e189"
+content-hash = "842c94acce0c1a646fa457e3c0c1d8dab918acb97eec1da43215ee8f0dbc0143"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = ">=3.8,<3.13"
 pyarrow = "^13.0.0"
 cloudpathlib = {extras = ["all"], version = "^0.15.0"}
 duckdb = "^0.8.0"
-parsl = "^2023.9.04"
+parsl = ">=2023.9.18"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
# Description

This PR updates `cytotable.utils._parsl_loaded` to use Parsl's ConfigurationError to help detect previously loaded configurations as part of a new Parsl release. More details can be found within #94 and https://github.com/cytomining/CytoTable/issues/90#issuecomment-1726359298 .

Many thanks go to @sbamin for highlighting the issue here: https://github.com/cytomining/CytoTable/issues/90#issuecomment-1726331209

References #94 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
