### PR TITLE
Move to offset-based joins

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -648,7 +648,22 @@ def _concat_source_group(
 
 
 @python_app
-def _prepare_join_sql(sources: Dict[str, List[Dict[str, Any]]], joins: str):
+def _prepare_join_sql(sources: Dict[str, List[Dict[str, Any]]], joins: str) -> str:
+    """
+    Prepare join SQL statement with actual locations of data based on the sources.
+
+    Args:
+        sources: Dict[str, List[Dict[str, Any]]]:
+            Grouped datasets of files which will be used by other functions.
+            Includes the metadata concerning location of actual data.
+        joins: str:
+            DuckDB-compatible SQL which will be used to perform the join
+            operations using the join_group keys as a reference.
+
+    Returns:
+        str:
+            String representing the SQL to be used in later join work.
+    """
     import pathlib
 
     # replace with real location of sources for join sql
@@ -1096,7 +1111,6 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
                                 chunk_size=chunk_size,
                                 offset=offset,
                                 dest_path=expanded_dest_path,
-                                data_type_cast_map=data_type_cast_map,
                             ),
                             source_group_name=source_group_name,
                             identifying_columns=identifying_columns,

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -274,7 +274,6 @@ def _source_chunk_to_parquet(
     chunk_size: int,
     offset: int,
     dest_path: str,
-    data_type_cast_map: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Export source data to chunked parquet file using chunk size and offsets.
@@ -701,7 +700,6 @@ def _join_source_chunk(
     # Attempt to read the data to parquet file
     # using duckdb for extraction and pyarrow for
     # writing data to a parquet file.
-
     # read data with chunk size + offset
     # and export to parquet
     with _duckdb_reader() as ddb_reader:

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -647,8 +647,11 @@ def _concat_source_group(
     return concatted
 
 
-@python_app
-def _prepare_join_sql(sources: Dict[str, List[Dict[str, Any]]], joins: str) -> str:
+@python_app()
+def _prepare_join_sql(
+    sources: Dict[str, List[Dict[str, Any]]],
+    joins: str,
+) -> str:
     """
     Prepare join SQL statement with actual locations of data based on the sources.
 

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -195,11 +195,11 @@ config = {
                 cytoplasm.Metadata_TableNumber = image.Metadata_TableNumber
                 AND cytoplasm.Metadata_ImageNumber = image.Metadata_ImageNumber
             LEFT JOIN read_parquet('cells.parquet') AS cells ON
-                cells.Metadata_TableNumber = cells.Metadata_TableNumber
+                cells.Metadata_TableNumber = cytoplasm.Metadata_TableNumber
                 AND cells.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
                 AND cells.Cells_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Cells
             LEFT JOIN read_parquet('nuclei.parquet') AS nuclei ON
-                nuclei.Metadata_TableNumber = nuclei.Metadata_TableNumber
+                nuclei.Metadata_TableNumber = cytoplasm.Metadata_TableNumber
                 AND nuclei.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
                 AND nuclei.Nuclei_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Nuclei
         """,

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -26,8 +26,6 @@ config = {
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
         "CONFIG_CHUNK_SIZE": 1000,
-        # chunking columns to use along with chunk size for join operations
-        "CONFIG_CHUNK_COLUMNS": ("Metadata_ImageNumber",),
         # compartment and metadata joins performed using DuckDB SQL
         # and modified at runtime as needed
         "CONFIG_JOINS": """
@@ -73,8 +71,6 @@ config = {
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
         "CONFIG_CHUNK_SIZE": 1000,
-        # chunking columns to use along with chunk size for join operations
-        "CONFIG_CHUNK_COLUMNS": ("Metadata_ImageNumber",),
         # compartment and metadata joins performed using DuckDB SQL
         # and modified at runtime as needed
         "CONFIG_JOINS": """
@@ -126,8 +122,6 @@ config = {
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
         "CONFIG_CHUNK_SIZE": 1000,
-        # chunking columns to use along with chunk size for join operations
-        "CONFIG_CHUNK_COLUMNS": ("Metadata_ImageNumber",),
         # compartment and metadata joins performed using DuckDB SQL
         # and modified at runtime as needed
         "CONFIG_JOINS": """
@@ -181,8 +175,6 @@ config = {
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
         "CONFIG_CHUNK_SIZE": 1000,
-        # chunking columns to use along with chunk size for join operations
-        "CONFIG_CHUNK_COLUMNS": ("Metadata_ImageNumber",),
         # compartment and metadata joins performed using DuckDB SQL
         # and modified at runtime as needed
         "CONFIG_JOINS": """
@@ -203,11 +195,11 @@ config = {
                 cytoplasm.Metadata_TableNumber = image.Metadata_TableNumber
                 AND cytoplasm.Metadata_ImageNumber = image.Metadata_ImageNumber
             LEFT JOIN read_parquet('cells.parquet') AS cells ON
-                cells.Metadata_TableNumber = cytoplasm.Metadata_TableNumber
+                cells.Metadata_TableNumber = cells.Metadata_TableNumber
                 AND cells.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
                 AND cells.Cells_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Cells
             LEFT JOIN read_parquet('nuclei.parquet') AS nuclei ON
-                nuclei.Metadata_TableNumber = cytoplasm.Metadata_TableNumber
+                nuclei.Metadata_TableNumber = nuclei.Metadata_TableNumber
                 AND nuclei.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
                 AND nuclei.Nuclei_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Nuclei
         """,

--- a/docs/source/python-api.md
+++ b/docs/source/python-api.md
@@ -21,10 +21,6 @@ Convert
 
 |
 
-.. autofunction:: _get_join_chunks
-
-|
-
 .. autofunction:: _get_table_columns_and_types
 
 |
@@ -38,6 +34,10 @@ Convert
 |
 
 .. autofunction:: _join_source_chunk
+
+|
+
+.. autofunction:: _prepare_join_sql
 
 |
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -326,12 +326,12 @@ def test_prepare_join_sql(
         SELECT
             *
         FROM
-            read_parquet(['<temp_dir_location>/example_dest/image/0/image.parquet']) AS image
-        LEFT JOIN read_parquet(['<temp_dir_location>/example_dest/cytoplasm/1/cytoplasm.parquet']) AS cytoplasm ON
+            read_parquet(['<temp_dir_location>/image.parquet']) AS image
+        LEFT JOIN read_parquet(['<temp_dir_location>/cytoplasm.parquet']) AS cytoplasm ON
             cytoplasm.ImageNumber = image.ImageNumber
-        LEFT JOIN read_parquet(['<temp_dir_location>/example_dest/cells/2/cells.parquet']) AS cells ON
+        LEFT JOIN read_parquet(['<temp_dir_location>/cells.parquet']) AS cells ON
             cells.ImageNumber = cytoplasm.ImageNumber
-        LEFT JOIN read_parquet(['<temp_dir_location>/example_dest/nuclei/3/nuclei.parquet']) AS nuclei ON
+        LEFT JOIN read_parquet(['<temp_dir_location>/nuclei.parquet']) AS nuclei ON
             nuclei.ImageNumber = cytoplasm.ImageNumber
     """
 
@@ -359,6 +359,9 @@ def test_prepare_join_sql(
             .arrow()
             .to_pydict()
         )
+
+    # check that we received data back
+    assert len(result) == 9
 
 
 def test_join_source_chunk(load_parsl_default: None, fx_tempdir: str):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -314,6 +314,13 @@ def test_concat_source_group(
         ).result()
 
 
+def test_prepare_join_sql(load_parsl_default: None):
+    """
+    Tests _prepare_join_sql
+    """
+
+    pass
+
 def test_join_source_chunk(load_parsl_default: None, fx_tempdir: str):
     """
     Tests _join_source_chunk


### PR DESCRIPTION
# Description

This PR is influenced from discussions in #111 where we found the `chunk_columns` parameter can be cause for unexpected issues when attempting to join datasets which share very few of the same numeric identifying columns (by name). My hope is that the change reduces the complexity of the code while allowing similar functionality by following a similar convention to initial data extraction into Parquet (performed within `_source_chunk_to_parquet`).

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
