### PR TITLE
Add weekly testing for preventative awareness of external changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # runs every Wednesday at 7 AM UTC
+    - cron: "0 7 * * 3"
 
 jobs:
   run_tests:


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a weekly check occurring at 7 AM UTC on Wednesdays to help detect external changes that could effect CytoTable (such as dependency updates). This change comes as a result of the issues in #163, which were discovered by @shntnu in the process of attempting to use CytoTable. Generally, I expect this to happen again with other dependencies over time (I believe we've also encountered similar issues with Parsl, for example), so this is an attempt to add a simple solution towards prevention. After this change completes, my hope would be that we might have early awareness of these types of issues in the future such that users don't have as much burden to troubleshoot.

References #163

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
