### PR TITLE
Remove duplicative all-at-once concatenate with join operations

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -2,7 +2,6 @@
 CytoTable: convert - transforming data for use with pyctyominer.
 """
 
-
 import itertools
 import logging
 import uuid
@@ -840,19 +839,6 @@ def _concat_join_sources(
     # remove dir if we have it
     if pathlib.Path(dest_path).is_dir():
         shutil.rmtree(path=dest_path)
-
-    # write the concatted result as a parquet file
-    _write_parquet_table_with_metadata(
-        table=pa.concat_tables(
-            tables=[
-                parquet.read_table(
-                    table_path, memory_map=CYTOTABLE_ARROW_USE_MEMORY_MAPPING
-                )
-                for table_path in join_sources
-            ]
-        ),
-        where=dest_path,
-    )
 
     # build a parquet file writer which will be used to append files
     # as a single concatted parquet file, referencing the first file's schema


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR removes a duplicative and all-at-once concatenate during CytoTable join operations. It was discovered while trying to replicate / confirm findings for #38 with `SQ00014613.sqlite` (which appears to no longer face direct challenges with data value translation but faces large memory resource consumption issues as a result of the removed block in this PR). After this is applied we should see performance benefits (as join concatenation will only take place once) and better opportunity to avoid memory resource constraint issues.

References #38 
Likely effects discussion on recommendations in #163 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
