### PR TITLE
Move to keyset pagination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, pagination-changes]
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run tests
 
 on:
   push:
-    branches: [main, pagination-changes]
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:

--- a/cytotable/constants.py
+++ b/cytotable/constants.py
@@ -68,13 +68,6 @@ SQLITE_AFFINITY_DATA_TYPE_SYNONYMS = {
     ],
 }
 
-# metadata column names and types for internal use within CytoTable
-CYOTABLE_META_COLUMN_TYPES = {
-    "cytotable_meta_source_path": "VARCHAR",
-    "cytotable_meta_offset": "BIGINT",
-    "cytotable_meta_rownum": "BIGINT",
-}
-
 CYTOTABLE_DEFAULT_PARQUET_METADATA = {
     "data-producer": "https://github.com/cytomining/CytoTable",
     "data-producer-version": str(_get_cytotable_version()),

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -180,7 +180,7 @@ def _get_table_keyset_pagination_sets(
     page_key: str,
     source: Optional[Dict[str, Any]] = None,
     sql_stmt: Optional[str] = None,
-) -> Union[List[Any], None]:
+) -> Union[List[Tuple[Union[int, float], Union[int, float]]], None]:
     """
     Get table data chunk keys for later use in capturing segments
     of values. This work also provides a chance to catch problematic
@@ -261,7 +261,7 @@ def _get_table_keyset_pagination_sets(
 def _source_chunk_to_parquet(
     source_group_name: str,
     source: Dict[str, Any],
-    pageset: Tuple[int, int],
+    pageset: Tuple[Union[int, float], Union[int, float]],
     dest_path: str,
     sort_output: bool,
 ) -> str:
@@ -274,8 +274,6 @@ def _source_chunk_to_parquet(
         source: Dict[str, Any]
             Contains the source data to be chunked. Represents a single
             file or table of some kind along with collected information about table.
-        page_keys: str:
-            The table and column names to be used for key pagination.
         pageset: Tuple[int, int]
             The pageset for chunking the data from source.
         dest_path: str

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1057,7 +1057,8 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
         ]
         if not matching_keys:
             raise CytoTableException(
-                f"No matching key found in page_keys for source_group_name: {source_group_name}"
+                f"No matching key found in page_keys for source_group_name: {source_group_name}."
+                "Please include a pagination key based on a column name from the table."
             )
 
     # prepare pagesets for chunked data export from source tables
@@ -1420,7 +1421,10 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
         raise CytoTableException(
             (
                 "When using join=True one must pass a 'join' pagination key "
-                "in the page_keys parameter."
+                "in the page_keys parameter. The 'join' pagination key is a column "
+                "name found within the joined results based on the SQL provided from "
+                "the joins parameter. This special key is required as not all columns "
+                "from the source tables might not be included."
             )
         )
 

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -202,10 +202,10 @@ def _get_table_keyset_pagination_sets(
     """
 
     import logging
-
-    import duckdb
     import sqlite3
     from contextlib import closing
+
+    import duckdb
 
     from cytotable.exceptions import NoInputDataException
     from cytotable.utils import _duckdb_reader
@@ -1295,7 +1295,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
     infer_common_schema: bool = True,
     drop_null: bool = False,
     data_type_cast_map: Optional[Dict[str, str]] = None,
-    page_keys: Dict[str, str] = None,
+    page_keys: Optional[Dict[str, str]] = None,
     sort_output: bool = True,
     preset: Optional[str] = "cellprofiler_csv",
     parsl_config: Optional[parsl.Config] = None,
@@ -1476,7 +1476,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             drop_null=drop_null,
             data_type_cast_map=data_type_cast_map,
             sort_output=sort_output,
-            page_keys=page_keys,
+            page_keys=cast(dict, page_keys),
             **kwargs,
         )
 

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -207,7 +207,7 @@ def _get_table_keyset_pagination_sets(
     import duckdb
 
     from cytotable.exceptions import NoInputDataException
-    from cytotable.utils import _duckdb_reader
+    from cytotable.utils import _duckdb_reader, _generate_pagesets
 
     logger = logging.getLogger(__name__)
 
@@ -254,28 +254,7 @@ def _get_table_keyset_pagination_sets(
             keys = ddb_reader.execute(sql_query).fetchall()
             keys = [key[0] for key in keys]
 
-    # Create chunks of keys
-    chunks = []
-    i = 0
-    while i < len(keys):
-        start_key = keys[i]
-        end_index = min(i + chunk_size, len(keys)) - 1
-        end_key = keys[end_index]
-
-        # Ensure non-overlapping by incrementing the start of the next range
-        next_start_index = end_index + 1
-        if next_start_index < len(keys):
-            next_start_key = keys[next_start_index]
-            while next_start_key == end_key and next_start_index + 1 < len(keys):
-                next_start_index += 1
-                next_start_key = keys[next_start_index]
-            chunks.append((start_key, next_start_key - 1))
-        else:
-            chunks.append((start_key, end_key))
-
-        i = next_start_index
-
-    return chunks
+    return _generate_pagesets(keys, chunk_size)
 
 
 @python_app

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -194,6 +194,11 @@ def _get_table_keyset_pagination_sets(
             The size in rowcount of the chunks to create.
         page_key: str
             The column name to be used as the key for pagination.
+            Expected to be of numeric type (int, float) for ordering.
+        sql_stmt:
+            Optional sql statement to form the pagination set from.
+            Default behavior extracts pagination sets from the full
+            data source.
 
     Returns:
         List[Any]
@@ -1300,6 +1305,10 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             https://arrow.apache.org/docs/python/api/datatypes.html
         page_keys: str:
             The table and column names to be used for key pagination.
+            Uses the form: {"table_name":"column_name"}.
+            Expects columns to include numeric data (ints or floats).
+            Interacts with the `chunk_size` parameter to form
+            pages of `chunk_size`.
         sort_output: bool (Default value = True)
             Specifies whether to sort cytotable output or not.
         drop_null: bool (Default value = False)

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -228,14 +228,14 @@ def _get_table_keyset_pagination_sets(
                 else:
                     sql_query = f"SELECT {page_key} FROM sqlite_scan('{source_path}', '{table_name}') ORDER BY {page_key}"
 
-                keys = [key[0] for key in ddb_reader.execute(sql_query).fetchall()]
+                page_keys = [results[0] for results in ddb_reader.execute(sql_query).fetchall()]
 
         # exception case for when we have mixed types
         # (i.e. integer col with string and ints) in a sqlite column
         except duckdb.TypeMismatchException:
             with closing(sqlite3.connect(source_path)) as cx:
                 with cx:
-                    keys = [
+                    page_keys = [
                         key[0]
                         for key in cx.execute(
                             f"SELECT {page_key} FROM {table_name} ORDER BY {page_key};"
@@ -256,10 +256,10 @@ def _get_table_keyset_pagination_sets(
     elif sql_stmt is not None:
         with _duckdb_reader() as ddb_reader:
             sql_query = f"SELECT {page_key} FROM ({sql_stmt}) ORDER BY {page_key}"
-            keys = ddb_reader.execute(sql_query).fetchall()
-            keys = [key[0] for key in keys]
+            page_keys = ddb_reader.execute(sql_query).fetchall()
+            page_keys = [key[0] for key in page_keys]
 
-    return _generate_pagesets(keys, chunk_size)
+    return _generate_pagesets(page_keys, chunk_size)
 
 
 @python_app

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -228,7 +228,9 @@ def _get_table_keyset_pagination_sets(
                 else:
                     sql_query = f"SELECT {page_key} FROM sqlite_scan('{source_path}', '{table_name}') ORDER BY {page_key}"
 
-                page_keys = [results[0] for results in ddb_reader.execute(sql_query).fetchall()]
+                page_keys = [
+                    results[0] for results in ddb_reader.execute(sql_query).fetchall()
+                ]
 
         # exception case for when we have mixed types
         # (i.e. integer col with string and ints) in a sqlite column

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -99,7 +99,6 @@ def _get_table_columns_and_types(
             )
 
     except duckdb.Error as e:
-        print(source["pagesets"])
         # if we see a mismatched type error
         # run a more nuanced query through sqlite
         # to handle the mixed types
@@ -1120,8 +1119,6 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
         if len(source_group_vals) > 0
     }
 
-    print(invalid_files_dropped)
-
     # gather column names and types from source tables
     column_names_and_types_gathered = {
         source_group_name: [
@@ -1214,8 +1211,6 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
     if join:
         # evaluate the results as they're used multiple times below
         evaluated_results = evaluate_futures(results)
-
-        print(evaluated_results)
 
         prepared_joins_sql = _prepare_join_sql(
             sources=evaluated_results, joins=joins

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -33,7 +33,7 @@ def _get_table_columns_and_types(
 
     Args:
         source: Dict[str, Any]
-            Contains the source data to be chunked. Represents a single
+            Contains source data details. Represents a single
             file or table of some kind.
         sort_output:
             Specifies whether to sort cytotable output or not.
@@ -263,7 +263,7 @@ def _get_table_keyset_pagination_sets(
 
 
 @python_app
-def _source_chunk_to_parquet(
+def _source_pageset_to_parquet(
     source_group_name: str,
     source: Dict[str, Any],
     pageset: Tuple[Union[int, float], Union[int, float]],
@@ -714,7 +714,7 @@ def _prepare_join_sql(
 
 
 @python_app
-def _join_source_chunk(
+def _join_source_pageset(
     dest_path: str,
     joins: str,
     page_key: str,
@@ -1129,7 +1129,7 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
                         # perform column renaming and create potential return result
                         _prepend_column_name(
                             # perform chunked data export to parquet using pagesets
-                            table_path=_source_chunk_to_parquet(
+                            table_path=_source_pageset_to_parquet(
                                 source_group_name=source_group_name,
                                 source=source,
                                 pageset=pageset,
@@ -1205,7 +1205,7 @@ def _to_parquet(  # pylint: disable=too-many-arguments, too-many-locals
         # map joined results based on the join groups gathered above
         # note: after mapping we end up with a list of strings (task returns str)
         join_sources_result = [
-            _join_source_chunk(
+            _join_source_pageset(
                 # gather the result of concatted sources prior to
                 # join group merging as each mapped task run will need
                 # full concat results

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -193,7 +193,7 @@ def _get_table_keyset_pagination_sets(
         chunk_size: int
             The size in rowcount of the chunks to create.
         page_key: str
-            The column name to be used as the key for pagination.
+            The column name to be used to identify pagination chunks.
             Expected to be of numeric type (int, float) for ordering.
         sql_stmt:
             Optional sql statement to form the pagination set from.

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -70,9 +70,9 @@ config = {
         ),
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
-            "cells": "ObjectNumber",
-            "nuclei": "ObjectNumber",
-            "cytoplasm": "ObjectNumber",
+            "cells": "Cells_Number_Object_Number",
+            "nuclei": "Nuclei_Number_Object_Number",
+            "cytoplasm": "Cytoplasm_Number_Object_Number",
             "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
@@ -178,9 +178,9 @@ config = {
         ),
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
-            "cells": "ObjectNumber",
-            "nuclei": "ObjectNumber",
-            "cytoplasm": "ObjectNumber",
+            "cells": "Cells_Number_Object_Number",
+            "nuclei": "Nuclei_Number_Object_Number",
+            "cytoplasm": "Cytoplasm_Number_Object_Number",
             "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
@@ -284,7 +284,7 @@ config = {
             "T",
         ),
         "CONFIG_PAGE_KEYS": {
-            "test": "OBJECT ID",
+            "test": '"OBJECT ID"',
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -22,6 +22,9 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
             "cells": "ObjectNumber",
@@ -68,6 +71,9 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
             "cells": "Cells_Number_Object_Number",
@@ -118,6 +124,9 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
             "cells": "ObjectNumber",
@@ -176,6 +185,9 @@ config = {
             "Cells_Number_Object_Number",
             "Nuclei_Number_Object_Number",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
             "cells": "Cells_Number_Object_Number",
@@ -231,6 +243,9 @@ config = {
             "Cells_ObjectNumber",
             "Nuclei_ObjectNumber",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "image": "ImageNumber",
             "cells": "ObjectNumber",
@@ -283,6 +298,9 @@ config = {
             "Z",
             "T",
         ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
         "CONFIG_PAGE_KEYS": {
             "test": '"OBJECT ID"',
         },

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -22,6 +22,13 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number"
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
@@ -61,6 +68,13 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number"
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
@@ -104,6 +118,13 @@ config = {
             "Parent_Cells",
             "Parent_Nuclei",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number"
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
@@ -155,6 +176,13 @@ config = {
             "Cells_Number_Object_Number",
             "Nuclei_Number_Object_Number",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number"
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
@@ -203,6 +231,13 @@ config = {
             "Cells_ObjectNumber",
             "Nuclei_ObjectNumber",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number"
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.
@@ -248,6 +283,9 @@ config = {
             "Z",
             "T",
         ),
+        "CONFIG_PAGE_KEYS": {
+            "test": "OBJECT ID",
+        },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
         # and system used by this library.

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -27,7 +27,7 @@ config = {
             "cells": "ObjectNumber",
             "nuclei": "ObjectNumber",
             "cytoplasm": "ObjectNumber",
-            "join": "Cytoplasm_Number_Object_Number"
+            "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
@@ -73,7 +73,7 @@ config = {
             "cells": "ObjectNumber",
             "nuclei": "ObjectNumber",
             "cytoplasm": "ObjectNumber",
-            "join": "Cytoplasm_Number_Object_Number"
+            "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
@@ -123,7 +123,7 @@ config = {
             "cells": "ObjectNumber",
             "nuclei": "ObjectNumber",
             "cytoplasm": "ObjectNumber",
-            "join": "Cytoplasm_Number_Object_Number"
+            "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
@@ -181,7 +181,7 @@ config = {
             "cells": "ObjectNumber",
             "nuclei": "ObjectNumber",
             "cytoplasm": "ObjectNumber",
-            "join": "Cytoplasm_Number_Object_Number"
+            "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data
@@ -236,7 +236,7 @@ config = {
             "cells": "ObjectNumber",
             "nuclei": "ObjectNumber",
             "cytoplasm": "ObjectNumber",
-            "join": "Cytoplasm_Number_Object_Number"
+            "join": "Cytoplasm_Number_Object_Number",
         },
         # chunk size to use for join operations to help with possible performance issues
         # note: this number is an estimate and is may need changes contingent on data

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -173,7 +173,6 @@ def _duckdb_reader() -> duckdb.DuckDBPyConnection:
 def _sqlite_mixed_type_query_to_parquet(
     source_path: str,
     table_name: str,
-    chunk_size: int,
     page_key: str,
     pageset: Tuple[int, int],
     sort_output: bool,
@@ -188,8 +187,6 @@ def _sqlite_mixed_type_query_to_parquet(
             A str which is a path to a SQLite database file.
         table_name: str:
             The name of the table being queried.
-        chunk_size: int:
-            Row count to use for chunked output.
         page_key: str,
             ...
         pageset: Tuple[int, int]:

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -176,7 +176,7 @@ def _sqlite_mixed_type_query_to_parquet(
     source_path: str,
     table_name: str,
     page_key: str,
-    pageset: Tuple[int, int],
+    pageset: Tuple[Union[int, float], Union[int, float]],
     sort_output: bool,
 ) -> str:
     """

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -271,14 +271,7 @@ def _sqlite_mixed_type_query_to_parquet(
                 {', '.join(query_parts)}
             FROM {table_name}
             WHERE {page_key} BETWEEN {pageset[0]} AND {pageset[1]}
-            ORDER BY {page_key};
-            """
-            if sort_output
-            else f"""
-            SELECT
-                {', '.join(query_parts)}
-            FROM {table_name}
-            WHERE {page_key} BETWEEN {pageset[0]} AND {pageset[1]};
+            {"ORDER BY " + page_key if sort_output else ""};
             """
         )
 

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -192,7 +192,7 @@ def _sqlite_mixed_type_query_to_parquet(
         page_key: str:
             The column name to be used to identify pagination chunks.
         pageset: Tuple[int, int]:
-            The pageset for chunking the data from source.
+            The range for values used for paginating data from source.
         sort_output: bool
             Specifies whether to sort cytotable output or not.
         add_cytotable_meta: bool, default=False:
@@ -591,7 +591,7 @@ def _generate_pagesets(
 
     # if we have no keys, raise an exception
     if not keys:
-        raise CytoTableException("No keys were provided to pageset generation process.")
+        raise CytoTableException("Keys were not provided to the pageset generation process.")
 
     # Initialize an empty list to store the chunks/pages
     chunks = []

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -187,8 +187,8 @@ def _sqlite_mixed_type_query_to_parquet(
             A str which is a path to a SQLite database file.
         table_name: str:
             The name of the table being queried.
-        page_key: str,
-            ...
+        page_key: str:
+            The column name to be used as the key for pagination.
         pageset: Tuple[int, int]:
             The pageset for chunking the data from source.
         sort_output: bool

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -190,7 +190,7 @@ def _sqlite_mixed_type_query_to_parquet(
         table_name: str:
             The name of the table being queried.
         page_key: str:
-            The column name to be used as the key for pagination.
+            The column name to be used to identify pagination chunks.
         pageset: Tuple[int, int]:
             The pageset for chunking the data from source.
         sort_output: bool

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -17,8 +17,6 @@ from parsl.config import Config
 from parsl.errors import NoDataFlowKernelError
 from parsl.executors import HighThroughputExecutor
 
-from cytotable.exceptions import CytoTableException
-
 logger = logging.getLogger(__name__)
 
 # reference the original init
@@ -617,3 +615,30 @@ def _generate_pagesets(
 
     # Return the list of chunks/pages
     return chunks
+
+
+def _natural_sort(list_to_sort):
+    """
+    Sorts the given iterable using natural sort adapted from approach
+    provided by the following link:
+    https://stackoverflow.com/a/4836734
+
+    Args:
+      list_to_sort: List:
+        The list to sort.
+
+    Returns:
+      List: The sorted list.
+    """
+    import re
+
+    return sorted(
+        list_to_sort,
+        # use a custom key to sort the list
+        key=lambda key: [
+            # use integer of c if it's a digit, otherwise str
+            int(c) if c.isdigit() else c
+            # Split the key into parts, separating numbers from alphabetic characters
+            for c in re.split("([0-9]+)", str(key))
+        ],
+    )

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -265,15 +265,13 @@ def _sqlite_mixed_type_query_to_parquet(
         ]
 
         # perform the select using the cases built above and using chunksize + offset
-        sql_stmt = (
-            f"""
+        sql_stmt = f"""
             SELECT
                 {', '.join(query_parts)}
             FROM {table_name}
             WHERE {page_key} BETWEEN {pageset[0]} AND {pageset[1]}
             {"ORDER BY " + page_key if sort_output else ""};
             """
-        )
 
         # execute the sql stmt
         cursor.execute(sql_stmt)

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -5,7 +5,7 @@ Utility functions for CytoTable
 import logging
 import os
 import pathlib
-from typing import Any, Dict, List, Optional, Union, cast, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import duckdb
 import parsl
@@ -207,9 +207,7 @@ def _sqlite_mixed_type_query_to_parquet(
 
     import pyarrow as pa
 
-    from cytotable.constants import (
-        SQLITE_AFFINITY_DATA_TYPE_SYNONYMS,
-    )
+    from cytotable.constants import SQLITE_AFFINITY_DATA_TYPE_SYNONYMS
     from cytotable.exceptions import DatatypeException
 
     # open sqlite3 connection

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -589,10 +589,6 @@ def _generate_pagesets(
             List of (start_key, end_key) tuples representing each page.
     """
 
-    # if we have no keys, raise an exception
-    if not keys:
-        raise CytoTableException("Keys were not provided to the pageset generation process.")
-
     # Initialize an empty list to store the chunks/pages
     chunks = []
 

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -286,3 +286,16 @@ Also see CytoTable's presets found here: :data:`presets.config <cytotable.preset
 
 Note: data software outside of CytoTable sometimes makes use of the term "merge" to describe capabilities which are similar to join (for ex. [`pandas.DataFrame.merge`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.merge.html).
 Within CytoTable, we opt to describe these operations with "join" to avoid confusion with software development alongside the technologies used (for example, [DuckDB SQL](https://duckdb.org/docs/archive/0.9.2/sql/introduction) includes no `MERGE` keyword).
+
+## Pagination
+
+CytoTable uses keyset pagination to help manage system-specific reasonable memory usage when working with large datasets.
+[Pagination](https://en.wikipedia.org/wiki/Pagination), sometimes also called paging or "data chunking", allows CytoTable to avoid loading entire datasets into memory at once while accomplishing tasks.
+Keyset pagination leverages existing column data as _pagesets_ to perform data extractions which focus on only a subset of the data as defined within the _pageset_ keys.
+We use keyset pagination to reduce the overall memory footprint during extractions where other methods inadvertently may not scale for whole dataset work (such as offset-based pagination, which extracts then drops the offset data)([see here for more information](https://use-the-index-luke.com/no-offset)).
+
+```{eval-rst}
+Keyset pagination definitions may be defined using the ``page_keys`` parameter: :code:`convert(..., page_keys={"table_name": "column_name" }, ...)` (:mod:`convert() <cytotable.convert.convert>`).
+The ``page_keys`` parameter expects a dictionary where the keys are names of tables and values which are columns to be used for the keyset pagination pages.
+Pagination is created in conjunction with the ``chunk_size`` parameter which indicates the size of each page.
+```

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -291,7 +291,7 @@ Within CytoTable, we opt to describe these operations with "join" to avoid confu
 
 CytoTable uses keyset pagination to help manage system-specific reasonable memory usage when working with large datasets.
 [Pagination](https://en.wikipedia.org/wiki/Pagination), sometimes also called paging or "data chunking", allows CytoTable to avoid loading entire datasets into memory at once while accomplishing tasks.
-Keyset pagination leverages existing column data as _pagesets_ to perform data extractions which focus on only a subset of the data as defined within the _pageset_ keys.
+Keyset pagination leverages existing column data as _pagesets_ to perform data extractions which focus on only a subset of the data as defined within the _pageset_ keys (see example usage below).
 We use keyset pagination to reduce the overall memory footprint during extractions where other methods inadvertently may not scale for whole dataset work (such as offset-based pagination, which extracts then drops the offset data)([see here for more information](https://use-the-index-luke.com/no-offset)).
 
 ```{eval-rst}

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -297,5 +297,8 @@ We use keyset pagination to reduce the overall memory footprint during extractio
 ```{eval-rst}
 Keyset pagination definitions may be defined using the ``page_keys`` parameter: :code:`convert(..., page_keys={"table_name": "column_name" }, ...)` (:mod:`convert() <cytotable.convert.convert>`).
 The ``page_keys`` parameter expects a dictionary where the keys are names of tables and values which are columns to be used for the keyset pagination pages.
-Pagination is created in conjunction with the ``chunk_size`` parameter which indicates the size of each page.
+Pagination is implemented in conjunction with the ``chunk_size`` parameter which indicates the size of each page.
+We provide preset configurations for these parameters through the ``preset`` parameter :code:`convert(..., preset="", ...)`.
+Customizing the ``chunk_size`` or ``page_keys`` parameters allows you to tune the process to the size of your data and the resources available on your system.
+For large datasets, smaller chunk sizes or specific pagination columns can help manage the workload by enabling smaller, more manageable data extraction at a time.
 ```

--- a/docs/source/python-api.md
+++ b/docs/source/python-api.md
@@ -33,7 +33,7 @@ Convert
 
 |
 
-.. autofunction:: _join_source_chunk
+.. autofunction:: _join_source_pageset
 
 |
 
@@ -49,7 +49,7 @@ Convert
 
 |
 
-.. autofunction:: _source_chunk_to_parquet
+.. autofunction:: _source_pageset_to_parquet
 
 |
 

--- a/docs/source/python-api.md
+++ b/docs/source/python-api.md
@@ -25,7 +25,7 @@ Convert
 
 |
 
-.. autofunction:: _get_table_chunk_offsets
+.. autofunction:: _get_table_keyset_pagination_sets
 
 |
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ from pyarrow import csv, parquet
 from pycytominer.cyto_utils.cells import SingleCells
 from sqlalchemy.util import deprecations
 
-from cytotable.constants import CYOTABLE_META_COLUMN_TYPES
 from cytotable.utils import _column_sort, _default_parsl_config, _parsl_loaded
 
 # filters sqlalchemy 2.0 uber warning
@@ -324,13 +323,7 @@ def fixture_example_local_sources(
         csv.write_csv(
             # we remove simulated cytotable metadata columns to be more realistic
             # (incoming sources would not usually contain these)
-            table.select(
-                [
-                    column
-                    for column in table.column_names
-                    if column not in CYOTABLE_META_COLUMN_TYPES
-                ]
-            ),
+            table.select(list(table.column_names)),
             f"{fx_tempdir}/example/{number}/{name}.csv",
         )
         # write example output

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1062,8 +1062,6 @@ def test_convert_cellprofiler_sqlite_pycytominer_merge(
     # properly perform comparisons as pycytominer and cytotable differ in their
     # datatyping implementations
 
-    print(cytotable_table.to_pandas().drop_duplicates().shape)
-
     assert pycytominer_table.schema.equals(
         cytotable_table.cast(target_schema=pycytominer_table.schema).schema
     )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -21,7 +21,6 @@ from parsl.app.app import python_app
 from pyarrow import csv, parquet
 from pycytominer.cyto_utils.cells import SingleCells
 
-from cytotable.constants import CYOTABLE_META_COLUMN_TYPES
 from cytotable.convert import (
     _concat_join_sources,
     _concat_source_group,
@@ -1262,11 +1261,7 @@ def test_in_carta_to_parquet(
 
         # drop cytotable metadata columns for comparisons (example sources won't contain these)
         cytotable_result_table = cytotable_result_table.select(
-            [
-                column
-                for column in cytotable_result_table.column_names
-                if column not in CYOTABLE_META_COLUMN_TYPES
-            ]
+            list(cytotable_result_table.column_names)
         )
 
         # check the data against one another

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -404,7 +404,7 @@ def test_prepare_join_sql(
                     WHERE
                         cells.Cells_ObjectNumber = cytoplasm.Cytoplasm_Parent_Cells
                         AND nuclei.Nuclei_ObjectNumber = cytoplasm.Cytoplasm_Parent_Nuclei
-                    """
+                    """,
             ).result()
         ).df()
 
@@ -1064,18 +1064,6 @@ def test_convert_cellprofiler_sqlite_pycytominer_merge(
     # datatyping implementations
 
     print(cytotable_table.to_pandas().drop_duplicates().shape)
-
-    import pandas as pd
-
-    pd.testing.assert_frame_equal(
-        pycytominer_table.to_pandas()
-        .sort_values(by=list(pycytominer_table.schema.names))
-        .reset_index(drop=True),
-        cytotable_table.to_pandas()
-        .drop_duplicates()
-        .sort_values(by=list(pycytominer_table.schema.names))
-        .reset_index(drop=True),
-    )
 
     assert pycytominer_table.schema.equals(
         cytotable_table.cast(target_schema=pycytominer_table.schema).schema

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -25,7 +25,7 @@ from cytotable.convert import (
     _concat_join_sources,
     _concat_source_group,
     _infer_source_group_common_schema,
-    _join_source_chunk,
+    _join_source_pageset,
     _prepare_join_sql,
     _prepend_column_name,
     _to_parquet,
@@ -434,9 +434,9 @@ def test_prepare_join_sql(
     }
 
 
-def test_join_source_chunk(load_parsl_default: None, fx_tempdir: str):
+def test_join_source_pageset(load_parsl_default: None, fx_tempdir: str):
     """
-    Tests _join_source_chunk
+    Tests _join_source_pageset
     """
 
     # form test path a
@@ -467,7 +467,7 @@ def test_join_source_chunk(load_parsl_default: None, fx_tempdir: str):
         where=test_path_b,
     )
 
-    result = _join_source_chunk(
+    result = _join_source_pageset(
         dest_path=f"{fx_tempdir}/destination.parquet",
         joins=f"""
             SELECT *

--- a/tests/test_convert_threaded.py
+++ b/tests/test_convert_threaded.py
@@ -102,31 +102,6 @@ def test_convert_s3_path_sqlite_join(
         # sequential s3 SQLite files. See below for more information
         # https://cloudpathlib.drivendata.org/stable/caching/#automatically
         local_cache_dir=f"{fx_tempdir}/sqlite_s3_cache/2",
-        # note: we use a custom join to limit the
-        # data processing required within the context
-        # of GitHub Actions runner image resources.
-        joins="""
-            SELECT
-                image.Image_TableNumber,
-                image.Metadata_ImageNumber,
-                image.Metadata_Plate,
-                image.Metadata_Well,
-                image.Image_Metadata_Site,
-                image.Image_Metadata_Row,
-                cytoplasm.* EXCLUDE (Metadata_ImageNumber),
-                cells.* EXCLUDE (Metadata_ImageNumber),
-                nuclei.* EXCLUDE (Metadata_ImageNumber)
-            FROM
-                (SELECT * FROM read_parquet('cytoplasm.parquet') LIMIT 5000) AS cytoplasm
-            LEFT JOIN (SELECT * FROM read_parquet('cells.parquet') LIMIT 5000) AS cells ON
-                cells.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
-                AND cells.Metadata_ObjectNumber = cytoplasm.Cytoplasm_Parent_Cells
-            LEFT JOIN (SELECT * FROM read_parquet('nuclei.parquet') LIMIT 5000) AS nuclei ON
-                nuclei.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
-                AND nuclei.Metadata_ObjectNumber = cytoplasm.Cytoplasm_Parent_Nuclei
-            LEFT JOIN (SELECT * FROM read_parquet('image.parquet') LIMIT 5000) AS image ON
-                image.Metadata_ImageNumber = cytoplasm.Metadata_ImageNumber
-        """,
     )
 
     # read only the metadata from parquet file

--- a/tests/test_convert_threaded.py
+++ b/tests/test_convert_threaded.py
@@ -108,10 +108,10 @@ def test_convert_s3_path_sqlite_join(
     parquet_file_meta = parquet.ParquetFile(s3_result).metadata
 
     # check the shape of the data
-    assert (parquet_file_meta.num_rows, parquet_file_meta.num_columns) == (5000, 5928)
+    assert (parquet_file_meta.num_rows, parquet_file_meta.num_columns) == (74226, 5928)
 
     # check that dropping duplicates results in the same shape
-    assert pd.read_parquet(s3_result).drop_duplicates().shape == (5000, 5928)
+    assert pd.read_parquet(s3_result).drop_duplicates().shape == (74226, 5928)
 
 
 def test_get_source_filepaths(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,92 @@
+"""
+Testing CytoTable utility functions found within util.py
+"""
+
+import pytest
+from cytotable.utils import _generate_pagesets
+from cytotable.exceptions import CytoTableException
+
+
+def test_generate_pageset():
+    """
+    Test the generate_pageset function with various scenarios.
+    """
+
+    # Test case with a single element
+    keys = [1]
+    chunk_size = 3
+    expected = [(1, 1)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case when chunk size is larger than the list
+    keys = [1, 2, 3]
+    chunk_size = 10
+    expected = [(1, 3)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with all elements being the same
+    keys = [1, 1, 1, 1, 1]
+    chunk_size = 2
+    expected = [(1, 1)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with one duplicate of chunk size and others
+    keys = [1, 1, 1, 2, 3, 4]
+    chunk_size = 3
+    expected = [(1, 1), (2, 4)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with a chunk size of one
+    keys = [1, 2, 3, 4, 5]
+    chunk_size = 1
+    expected = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with no duplicates
+    keys = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    chunk_size = 3
+    expected = [(1, 3), (4, 6), (7, 9), (10, 10)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with non-continuous keys
+    keys = [1, 3, 5, 7, 9, 12, 14]
+    chunk_size = 2
+    expected = [(1, 3), (5, 7), (9, 12), (14, 14)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with inconsistent duplicates
+    keys = [1, 1, 3, 4, 5, 5, 8, 8, 8]
+    chunk_size = 3
+    expected = [(1, 3), (4, 5), (8, 8)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Bigger test case with inconsistent duplicates
+    keys = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 12, 12, 12]
+    chunk_size = 3
+    expected = [(1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (12, 12)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Float test case with no duplicates
+    keys = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1]
+    chunk_size = 3
+    expected = [(1.1, 3.3), (4.4, 6.6), (7.7, 9.9), (10.1, 10.1)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Float test case with non-continuous float keys
+    keys = [1.1, 3.3, 5.5, 7.7, 9.9, 12.12, 14.14]
+    chunk_size = 2
+    expected = [(1.1, 3.3), (5.5, 7.7), (9.9, 12.12), (14.14, 14.14)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Float test case with inconsistent duplicates
+    keys = [1.1, 1.1, 3.3, 4.4, 5.5, 5.5, 8.8, 8.8, 8.8]
+    chunk_size = 3
+    expected = [(1.1, 3.3), (4.4, 5.5), (8.8, 8.8)]
+    assert _generate_pagesets(keys, chunk_size) == expected
+
+    # Test case with an empty list
+    keys = []
+    chunk_size = 3
+    expected = []
+    with pytest.raises(CytoTableException):
+        _generate_pagesets(keys, chunk_size)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ Testing CytoTable utility functions found within util.py
 
 import pytest
 
-from cytotable.exceptions import CytoTableException
-from cytotable.utils import _generate_pagesets
+from cytotable.utils import _generate_pagesets, _natural_sort
 
 
 def test_generate_pageset():  # pylint: disable=too-many-statements
@@ -84,3 +83,26 @@ def test_generate_pageset():  # pylint: disable=too-many-statements
     chunk_size = 3
     expected = [(1.1, 3.3), (4.4, 5.5), (8.8, 8.8)]
     assert _generate_pagesets(keys, chunk_size) == expected
+
+
+@pytest.mark.parametrize(
+    "input_list, expected",
+    [
+        ([], []),
+        (["a1"], ["a1"]),
+        (["a1", "a10", "a2", "a3"], ["a1", "a2", "a3", "a10"]),
+        (["1", "10", "2", "11", "21", "20"], ["1", "2", "10", "11", "20", "21"]),
+        (["b1", "a1", "b2", "a2"], ["a1", "a2", "b1", "b2"]),
+        (["apple1", "Apple10", "apple2"], ["Apple10", "apple1", "apple2"]),
+        (["a1", "A1", "a10", "A10"], ["A1", "A10", "a1", "a10"]),
+        (
+            ["a-1", "a-10", "b-2", "B-1", "b-3", "a-2", "A-3"],
+            ["A-3", "B-1", "a-1", "a-2", "a-10", "b-2", "b-3"],
+        ),
+    ],
+)
+def test_natural_sort(input_list, expected):
+    """
+    Tests for _natural_sort
+    """
+    assert _natural_sort(input_list) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,10 +84,3 @@ def test_generate_pageset():  # pylint: disable=too-many-statements
     chunk_size = 3
     expected = [(1.1, 3.3), (4.4, 5.5), (8.8, 8.8)]
     assert _generate_pagesets(keys, chunk_size) == expected
-
-    # Test case with an empty list
-    keys = []
-    chunk_size = 3
-    expected = []
-    with pytest.raises(CytoTableException):
-        _generate_pagesets(keys, chunk_size)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,12 @@ Testing CytoTable utility functions found within util.py
 """
 
 import pytest
-from cytotable.utils import _generate_pagesets
+
 from cytotable.exceptions import CytoTableException
+from cytotable.utils import _generate_pagesets
 
 
-def test_generate_pageset():
+def test_generate_pageset():  # pylint: disable=too-many-statements
     """
     Test the generate_pageset function with various scenarios.
     """


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR modifies "chunk" behavior to follow keyset pagination patterns. We gather sets of pages as `pagesets` which are based on a key per table which is used to help create pages of rows from tables. `pagesets` are gathered ahead of time to retain the ability to parallelize where appropriate. This change required a new configuration parameter to be specified per table and the overall join.

Operationally this reduces the amount of data stored in tables throughout, reduces the complexity of the sorting performed, and avoids unnecessary data loading which occurs during the use of `OFFSET`.

Changes here made it unnecessary to create metadata columns and as a result I've removed those from all spots I could find.

Changes here are intended to address #214 , which turned out to be more related to data size than the sorting implementation. This is confirmed by a now passing `large_data_tests` test of JUMP data using the full dataset (instead of a truncated version).

Closes #214

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
