### PR TITLE
Cleanup `parsl` executor resources after convert

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1653,4 +1653,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             **kwargs,
         )
 
+    # cleanup Parsl executor and related
+    parsl.dfk().cleanup()
+
     return output


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a change which cleans up `parsl` resources after convert is finished. I'm adding it after anecdotally noticing the executor process was remaining open and testing this within the following [notebook](https://colab.research.google.com/drive/1DVLu7wPNBtWGSNLRm50qKRZzXc6bdtAW) (and [gist backup](https://gist.github.com/d33bs/30e0dc9e37ebf4b0d9713eb74a1899a9)).

Closes #211

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
