### PR TITLE
Update pre-commit-lite conditions

### DIFF
--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -18,6 +18,7 @@ jobs:
           python-version: "3.10"
       # run pre-commit
       - uses: pre-commit/action@v3.0.1
+        id: pre_commit
       # run pre-commit ci lite for automated fixes
       - uses: pre-commit-ci/lite-action@v1.1.0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() if: ${{ !cancelled() }}if: ${{ !cancelled() }} steps.pre_commit.outcome == 'failure' }}

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -21,4 +21,4 @@ jobs:
         id: pre_commit
       # run pre-commit ci lite for automated fixes
       - uses: pre-commit-ci/lite-action@v1.1.0
-        if: ${{ !cancelled() if: ${{ !cancelled() }}if: ${{ !cancelled() }} steps.pre_commit.outcome == 'failure' }}
+        if: ${{ !cancelled() && steps.pre_commit.outcome == 'failure' }}


### PR DESCRIPTION
This PR updates the pre-commit-lite conditions so that only failures of pre-commit can trigger updates from pre-commit-lite. Without this change, updates may occur without pre-commit failures.