### PR TITLE
Add `cellprofiler_csv_full` preset (includes all image table data)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: check-yaml
     -   id: check-toml
 -   repo: https://github.com/python-poetry/poetry
-    rev: 2.3.2
+    rev: 2.4.1
     hooks:
     -   id: poetry-check
 -   repo: https://github.com/tox-dev/pyproject-fmt
@@ -59,11 +59,11 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/jendrikseipp/vulture
-    rev: v2.15
+    rev: v2.16
     hooks:
     -   id: vulture
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.1.0
     hooks:
     -   id: mypy
         exclude: >
@@ -77,7 +77,7 @@ repos:
     hooks:
     -   id: validate-cff
 -   repo: https://github.com/software-gardening/almanack
-    rev: v0.1.15
+    rev: v0.1.16
     hooks:
     -   id: almanack-check
 -   repo: https://github.com/PyCQA/pylint

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -55,6 +55,57 @@ config = {
                 AND nuclei.Metadata_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Nuclei
             """,
     },
+    "cellprofiler_csv_full": {
+        # version specifications using related references
+        "CONFIG_SOURCE_VERSION": {
+            "cellprofiler": "v4.0.0",
+        },
+        # names of source table compartments (for ex. cells.csv, etc.)
+        "CONFIG_NAMES_COMPARTMENTS": ("cells", "nuclei", "cytoplasm"),
+        # names of source table metadata (for ex. image.csv, etc.)
+        "CONFIG_NAMES_METADATA": ("image",),
+        # column names in any compartment or metadata tables which contain
+        # unique names to avoid renaming
+        "CONFIG_IDENTIFYING_COLUMNS": (
+            "ImageNumber",
+            "ObjectNumber",
+            "Metadata_Well",
+            "Metadata_Plate",
+            "Parent_Cells",
+            "Parent_Nuclei",
+        ),
+        # pagination keys for use with this data
+        # of the rough format "table" -> "column".
+        # note: page keys are expected to be numeric (int, float)
+        "CONFIG_PAGE_KEYS": {
+            "image": "ImageNumber",
+            "cells": "ObjectNumber",
+            "nuclei": "ObjectNumber",
+            "cytoplasm": "ObjectNumber",
+            "join": "Cytoplasm_Number_Object_Number",
+        },
+        # chunk size to use for join operations to help with possible performance issues
+        # note: this number is an estimate and is may need changes contingent on data
+        # and system used by this library.
+        "CONFIG_CHUNK_SIZE": 1000,
+        # compartment and metadata joins performed using DuckDB SQL
+        # and modified at runtime as needed
+        "CONFIG_JOINS": """
+            SELECT
+                image.*,
+                cytoplasm.* EXCLUDE (Metadata_ImageNumber),
+                cells.* EXCLUDE (Metadata_ImageNumber, Metadata_ObjectNumber),
+                nuclei.* EXCLUDE (Metadata_ImageNumber, Metadata_ObjectNumber)
+            FROM
+                read_parquet('cytoplasm.parquet') AS cytoplasm
+            LEFT JOIN read_parquet('cells.parquet') AS cells USING (Metadata_ImageNumber)
+            LEFT JOIN read_parquet('nuclei.parquet') AS nuclei USING (Metadata_ImageNumber)
+            LEFT JOIN read_parquet('image.parquet') AS image USING (Metadata_ImageNumber)
+            WHERE
+                cells.Metadata_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Cells
+                AND nuclei.Metadata_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Nuclei
+            """,
+    }
     "cellprofiler_sqlite": {
         # version specifications using related references
         "CONFIG_SOURCE_VERSION": {

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -105,7 +105,7 @@ config = {
                 cells.Metadata_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Cells
                 AND nuclei.Metadata_ObjectNumber = cytoplasm.Metadata_Cytoplasm_Parent_Nuclei
             """,
-    }
+    },
     "cellprofiler_sqlite": {
         # version specifications using related references
         "CONFIG_SOURCE_VERSION": {

--- a/cytotable/presets.py
+++ b/cytotable/presets.py
@@ -90,6 +90,10 @@ config = {
         "CONFIG_CHUNK_SIZE": 1000,
         # compartment and metadata joins performed using DuckDB SQL
         # and modified at runtime as needed
+        # note: unlike the cellprofiler_csv CONFIG_JOINS variant, this preset
+        # selects image.* in the SELECT list. Use this preset when you need all
+        # image-level fields rather than only Metadata_ImageNumber plus
+        # COLUMNS('Image_FileName_.*').
         "CONFIG_JOINS": """
             SELECT
                 image.*,


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds a preset which includes all data from CSV-based CellProfiler output. Specifically, we include all image table data, where the `cellprofiler_csv` only provides a small portion of the image table data. 

Related to discussion in #425 

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CellProfiler CSV-derived preset (cellprofiler_csv_full): exposes full image fields in joins, configures compartment identification and metadata, includes parent/child pagination keys, a default processing chunk size (1000), and targets CellProfiler v4.0.0 layout.
* **Chores**
  * Updated developer tooling pin versions for pre-commit hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->