### PR TITLE
Follow symlinked directories in local source discovery (fixes #440)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     hooks:
     -   id: vulture
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
     -   id: mypy
         exclude: >

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -5,6 +5,7 @@ Utility functions for CytoTable
 import logging
 import os
 import pathlib
+import sys
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
@@ -923,6 +924,26 @@ def find_anndata_metadata_field_names(
     return numeric_fields, non_numeric_fields
 
 
+def _glob_follow_symlinks(start: Path, pattern: str) -> Iterator[Path]:
+    """
+    Like ``Path.glob(pattern)``, but follows symlinked directories on every
+    Python version CytoTable supports. ``Path.glob`` only gained
+    ``recurse_symlinks=True`` in 3.13; on 3.10–3.12 we walk the tree with
+    ``os.walk(followlinks=True)`` and apply the post-``**/`` portion of the
+    pattern at each visited directory.
+    """
+    if sys.version_info >= (3, 13):
+        yield from start.glob(pattern, recurse_symlinks=True)
+        return
+
+    if pattern.startswith("**/"):
+        local_pattern = pattern[3:]
+        for root, _dirs, _files in os.walk(str(start), followlinks=True):
+            yield from Path(root).glob(local_pattern)
+    else:
+        yield from start.glob(pattern)
+
+
 def cloud_glob(
     start: Union[str, CloudPath, Path],
     pattern: str,
@@ -1018,7 +1039,7 @@ def cloud_glob(
     # ---- Branch 2: local Path ----
     if isinstance(start, Path):
         yielded = 0
-        for child in start.glob(pattern):
+        for child in _glob_follow_symlinks(start, pattern):
             yield child
             yielded += 1
             if max_matches is not None and yielded >= max_matches:
@@ -1042,7 +1063,7 @@ def cloud_glob(
         else:
             base = Path(start)
             yielded = 0
-            for child in base.glob(pattern):
+            for child in _glob_follow_symlinks(base, pattern):
                 yield child
                 yielded += 1
                 if max_matches is not None and yielded >= max_matches:

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -931,6 +931,18 @@ def _glob_pattern_matches(rel_parts: Tuple[str, ...], pat_parts: List[str]) -> b
     semantics: ``**`` matches zero or more components, ``*`` and ``?`` are
     fnmatch wildcards within a single component, and matching is anchored at
     the left of ``rel_parts``.
+
+    Args:
+        rel_parts:
+            Path components of the candidate, relative to the search root
+            (e.g. ``("analysis", "Cells.csv")``).
+        pat_parts:
+            Pattern components produced by splitting the glob on ``"/"``
+            (e.g. ``["**", "*.csv"]``).
+
+    Returns:
+        ``True`` if ``rel_parts`` matches ``pat_parts`` under the semantics
+        described above, else ``False``.
     """
     if not pat_parts:
         return not rel_parts
@@ -957,6 +969,17 @@ def _glob_follow_symlinks(start: Path, pattern: str) -> Iterator[Path]:
     tree with ``os.walk(followlinks=True)`` and match each entry's relative
     path against the full pattern, so any pattern accepted by ``Path.glob``
     works across versions.
+
+    Args:
+        start:
+            Root directory to glob under. Must reference a local or network
+            filesystem path.
+        pattern:
+            Glob pattern relative to ``start`` (e.g. ``"**/*.csv"``).
+
+    Yields:
+        ``pathlib.Path`` entries matching ``pattern``, deduplicated so that
+        two paths resolving to the same real file are only yielded once.
     """
     if sys.version_info >= (3, 13):
         # ``Path.glob(recurse_symlinks=True)`` yields each reachable path,
@@ -977,6 +1000,25 @@ def _glob_follow_symlinks(start: Path, pattern: str) -> Iterator[Path]:
 
 
 def _walk_and_match(start: Path, pattern: str) -> Iterator[Path]:
+    """
+    Walk ``start`` with ``os.walk(followlinks=True)`` and yield entries
+    whose path (relative to ``start``) matches ``pattern`` under
+    pathlib-glob semantics. Implements the 3.10-3.12 fallback used by
+    :func:`_glob_follow_symlinks`. Subdirectories whose real path has
+    already been entered are pruned before descent so that cyclic or
+    aliasing symlinks neither hang the walk nor produce duplicate yields.
+
+    Args:
+        start:
+            Root directory of the walk. Must reference a local or network
+            filesystem path.
+        pattern:
+            Glob pattern relative to ``start`` (e.g. ``"**/*.csv"``).
+
+    Yields:
+        ``pathlib.Path`` entries (files or directories) matching
+        ``pattern``.
+    """
     pat_parts = pattern.split("/")
     visited_dirs: Set[str] = {os.path.realpath(start)}
     for root, dirs, files in os.walk(start, followlinks=True):

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -2,12 +2,13 @@
 Utility functions for CytoTable
 """
 
+import fnmatch
 import logging
 import os
 import pathlib
 import sys
 from pathlib import Path, PurePosixPath
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 
 import boto3
 import duckdb
@@ -924,24 +925,77 @@ def find_anndata_metadata_field_names(
     return numeric_fields, non_numeric_fields
 
 
+def _glob_pattern_matches(rel_parts: Tuple[str, ...], pat_parts: List[str]) -> bool:
+    """
+    Match path components against pattern components using pathlib-glob
+    semantics: ``**`` matches zero or more components, ``*`` and ``?`` are
+    fnmatch wildcards within a single component, and matching is anchored at
+    the left of ``rel_parts``.
+    """
+    if not pat_parts:
+        return not rel_parts
+    head, *rest = pat_parts
+    if head == "**":
+        for i in range(len(rel_parts) + 1):
+            if _glob_pattern_matches(rel_parts[i:], rest):
+                return True
+        return False
+    if not rel_parts:
+        return False
+    if fnmatch.fnmatchcase(rel_parts[0], head):
+        return _glob_pattern_matches(rel_parts[1:], rest)
+    return False
+
+
 def _glob_follow_symlinks(start: Path, pattern: str) -> Iterator[Path]:
     """
     Like ``Path.glob(pattern)``, but follows symlinked directories on every
     Python version CytoTable supports. ``Path.glob`` only gained
-    ``recurse_symlinks=True`` in 3.13; on 3.10–3.12 we walk the tree with
-    ``os.walk(followlinks=True)`` and apply the post-``**/`` portion of the
-    pattern at each visited directory.
+    ``recurse_symlinks=True`` in 3.13; on 3.10-3.12 we walk the tree with
+    ``os.walk(followlinks=True)`` and match each entry's relative path
+    against the full pattern, so any pattern accepted by ``Path.glob`` works
+    across versions.
     """
     if sys.version_info >= (3, 13):
-        yield from start.glob(pattern, recurse_symlinks=True)
+        # ``Path.glob(recurse_symlinks=True)`` yields each reachable path,
+        # so two symlinks pointing at the same target produce duplicate
+        # entries. Deduplicate by real path. The 3.10-3.12 walker prunes
+        # alias directories before descent and so already yields unique
+        # paths.
+        seen: Set[str] = set()
+        for path in start.glob(pattern, recurse_symlinks=True):
+            real = os.path.realpath(path)
+            if real in seen:
+                continue
+            seen.add(real)
+            yield path
         return
 
-    if pattern.startswith("**/"):
-        local_pattern = pattern[3:]
-        for root, _dirs, _files in os.walk(str(start), followlinks=True):
-            yield from Path(root).glob(local_pattern)
-    else:
-        yield from start.glob(pattern)
+    yield from _walk_and_match(start, pattern)
+
+
+def _walk_and_match(start: Path, pattern: str) -> Iterator[Path]:
+    pat_parts = pattern.split("/")
+    visited_dirs: Set[str] = {os.path.realpath(start)}
+    for root, dirs, files in os.walk(start, followlinks=True):
+        # Prune subdirectories whose real path we've already entered, so that
+        # cyclic symlinks (e.g. ``start/foo -> start/``) cannot trap os.walk
+        # in an infinite descent.
+        kept = []
+        for d in dirs:
+            d_real = os.path.realpath(os.path.join(root, d))
+            if d_real in visited_dirs:
+                continue
+            visited_dirs.add(d_real)
+            kept.append(d)
+        dirs[:] = kept
+
+        root_path = Path(root)
+        for name in (*dirs, *files):
+            full = root_path / name
+            rel_parts = full.relative_to(start).parts
+            if _glob_pattern_matches(rel_parts, pat_parts):
+                yield full
 
 
 def cloud_glob(

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -950,11 +950,13 @@ def _glob_pattern_matches(rel_parts: Tuple[str, ...], pat_parts: List[str]) -> b
 def _glob_follow_symlinks(start: Path, pattern: str) -> Iterator[Path]:
     """
     Like ``Path.glob(pattern)``, but follows symlinked directories on every
-    Python version CytoTable supports. ``Path.glob`` only gained
-    ``recurse_symlinks=True`` in 3.13; on 3.10-3.12 we walk the tree with
-    ``os.walk(followlinks=True)`` and match each entry's relative path
-    against the full pattern, so any pattern accepted by ``Path.glob`` works
-    across versions.
+    Python version CytoTable supports. Intended for local and network
+    filesystems only - cloud object stores have no filesystem symlinks and
+    must use the ``CloudPath`` branches in :func:`cloud_glob`. ``Path.glob``
+    only gained ``recurse_symlinks=True`` in 3.13; on 3.10-3.12 we walk the
+    tree with ``os.walk(followlinks=True)`` and match each entry's relative
+    path against the full pattern, so any pattern accepted by ``Path.glob``
+    works across versions.
     """
     if sys.version_info >= (3, 13):
         # ``Path.glob(recurse_symlinks=True)`` yields each reachable path,
@@ -1015,8 +1017,12 @@ def cloud_glob(
           Use unsigned boto3 to list keys and yield unsigned cloudpathlib.S3Path.
       - Other CloudPath (e.g., GCS/Azure/local providers via cloudpathlib):
           Fallback to CloudPath.glob(pattern), yielding CloudPath.
-      - Local filesystem (pathlib.Path or non-s3 string):
-          Fallback to Path.glob(pattern), yielding pathlib.Path.
+      - Local or network filesystem (pathlib.Path or non-s3 string):
+          Walk with symlinked subdirectories followed, yielding pathlib.Path.
+
+    Symlink-following is only applied to the local-/network-filesystem
+    branch. Object stores (S3, GCS, Azure) do not have filesystem-level
+    symlinks, so the CloudPath branches are unaffected.
 
     Args:
         start:

--- a/docs/source/architecture.technical.md
+++ b/docs/source/architecture.technical.md
@@ -34,6 +34,12 @@ Local data paths are handled using [Python's Pathlib](https://docs.python.org/3/
 Cloud-based data paths are managed by [cloudpathlib](https://cloudpathlib.drivendata.org/~latest/).
 Reference the following page for how cloudpathlib client arguments may be used: [Overview: Data Source Locations](overview.md#data-source-locations)
 
+#### Data Paths - Symlinked Directories
+
+Source discovery follows symbolic links when scanning local and network filesystem paths, so layouts that expose data through symlinked subdirectories (for example, the directories produced by Nextflow's `stageInMode='symlink'`) are traversed transparently.
+Symlink-following applies only to local and network filesystem paths; cloud object stores (S3, GCS, Azure) have no filesystem-level symlinks and are unaffected.
+Two paths that resolve to the same real file are yielded once, and symlink cycles are detected and pruned so traversal always terminates.
+
 #### Data Paths - Cloud-based SQLite
 
 SQLite data stored in cloud-based paths are downloaded locally using cloudpathlib's [caching capabilities](https://cloudpathlib.drivendata.org/stable/caching/) to perform SQL queries.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -340,8 +340,7 @@ def test_cloud_glob_supports_non_double_star_prefixed_patterns(
     (staged / "analysis").symlink_to(real, target_is_directory=True)
 
     results = sorted(
-        str(p.relative_to(staged))
-        for p in cloud_glob(start=staged, pattern=pattern)
+        str(p.relative_to(staged)) for p in cloud_glob(start=staged, pattern=pattern)
     )
     assert results == expected
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,9 +265,9 @@ def test_cloud_glob_follows_symlinked_directories(tmp_path: pathlib.Path):
     """
     Regression test for https://github.com/cytomining/CytoTable/issues/440.
 
-    Mimics the Nextflow `stageInMode='symlink'` layout: per-site CSVs live in a
-    real directory and are exposed under a staging directory through a symlinked
-    subdirectory. cloud_glob must discover the CSVs via the symlinked path.
+    Per-site CSVs live in a real directory and are exposed under a separate
+    parent through a symlinked subdirectory. cloud_glob must discover the CSVs
+    via the symlinked path.
     """
     real = tmp_path / "real" / "analysis"
     real.mkdir(parents=True)
@@ -293,3 +293,90 @@ def test_cloud_glob_follows_symlinked_directories(tmp_path: pathlib.Path):
         for p in cloud_glob(start=str(staged_root), pattern="**/*.csv")
     )
     assert str_results == sorted(expected_names)
+
+    # The unrestricted '**/*' wildcard also yields directories, so filter to
+    # files before asserting we recover the same CSV set.
+    all_path_results = sorted(
+        p.name
+        for p in cloud_glob(start=staged_root, pattern="**/*")
+        if pathlib.Path(p).is_file()
+    )
+    assert all_path_results == sorted(expected_names)
+
+    all_str_results = sorted(
+        pathlib.Path(p).name
+        for p in cloud_glob(start=str(staged_root), pattern="**/*")
+        if pathlib.Path(p).is_file()
+    )
+    assert all_str_results == sorted(expected_names)
+
+
+def test_cloud_glob_supports_non_double_star_prefixed_patterns(
+    tmp_path: pathlib.Path,
+):
+    """
+    cloud_glob must honour pathlib-glob semantics for patterns that do not
+    start with ``**/`` even on Python versions that lack
+    ``Path.glob(recurse_symlinks=True)``.
+    """
+    real = tmp_path / "real" / "analysis"
+    real.mkdir(parents=True)
+    (real / "Cells.csv").write_text("a,b\n1,2\n")
+    (real / "notes.txt").write_text("ignore me")
+    nested = real / "nested"
+    nested.mkdir()
+    (nested / "Cells.csv").write_text("a,b\n3,4\n")
+
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    (staged / "analysis").symlink_to(real, target_is_directory=True)
+
+    # Anchored, no '**' anywhere — only the top-level CSV under analysis/.
+    anchored = sorted(
+        str(p.relative_to(staged))
+        for p in cloud_glob(start=staged, pattern="analysis/*.csv")
+    )
+    assert anchored == ["analysis/Cells.csv"]
+
+    # '**' in the middle of the pattern.
+    mid_double_star = sorted(
+        str(p.relative_to(staged))
+        for p in cloud_glob(start=staged, pattern="analysis/**/*.csv")
+    )
+    assert mid_double_star == ["analysis/Cells.csv", "analysis/nested/Cells.csv"]
+
+
+def test_cloud_glob_deduplicates_paths_with_same_real_target(
+    tmp_path: pathlib.Path,
+):
+    """
+    When the same file is reachable through both a real path and a symlink
+    inside the search tree, cloud_glob must yield it only once.
+    """
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "Cells.csv").write_text("a,b\n1,2\n")
+
+    # 'mirror' points back at the real directory inside the same search tree,
+    # so a naive walk would yield 'real/Cells.csv' and 'mirror/Cells.csv'.
+    (tmp_path / "mirror").symlink_to(real, target_is_directory=True)
+
+    results = list(cloud_glob(start=tmp_path, pattern="**/*.csv"))
+    assert len(results) == 1
+    assert pathlib.Path(results[0]).name == "Cells.csv"
+
+
+def test_cloud_glob_terminates_on_cyclic_symlinks(tmp_path: pathlib.Path):
+    """
+    A symlink cycle inside the search tree must not cause cloud_glob to hang
+    or recurse without bound.
+    """
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "Cells.csv").write_text("a,b\n1,2\n")
+    # 'loop' under sub points back at the search root, creating a cycle:
+    # tmp_path -> sub -> loop -> tmp_path -> sub -> ...
+    (sub / "loop").symlink_to(tmp_path, target_is_directory=True)
+
+    results = list(cloud_glob(start=tmp_path, pattern="**/*.csv"))
+    assert [pathlib.Path(p).name for p in results] == ["Cells.csv"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -259,3 +259,37 @@ def test_cloud_glob(root_path: str, max_matches: int, expected_result: List[str]
         )
 
     assert result == sorted(expected_result)
+
+
+def test_cloud_glob_follows_symlinked_directories(tmp_path: pathlib.Path):
+    """
+    Regression test for https://github.com/cytomining/CytoTable/issues/440.
+
+    Mimics the Nextflow `stageInMode='symlink'` layout: per-site CSVs live in a
+    real directory and are exposed under a staging directory through a symlinked
+    subdirectory. cloud_glob must discover the CSVs via the symlinked path.
+    """
+    real = tmp_path / "real" / "analysis"
+    real.mkdir(parents=True)
+    expected_names = ["Cells.csv", "Cytoplasm.csv", "Image.csv", "Nuclei.csv"]
+    for name in expected_names:
+        (real / name).write_text("ImageNumber,ObjectNumber\n1,1\n")
+
+    staged = tmp_path / "staged" / "1"
+    staged.mkdir(parents=True)
+    (staged / "analysis").symlink_to(real, target_is_directory=True)
+
+    staged_root = tmp_path / "staged"
+
+    # Path input
+    path_results = sorted(
+        p.name for p in cloud_glob(start=staged_root, pattern="**/*.csv")
+    )
+    assert path_results == sorted(expected_names)
+
+    # str input (exercises the string-path branch)
+    str_results = sorted(
+        pathlib.Path(p).name
+        for p in cloud_glob(start=str(staged_root), pattern="**/*.csv")
+    )
+    assert str_results == sorted(expected_names)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,13 +261,29 @@ def test_cloud_glob(root_path: str, max_matches: int, expected_result: List[str]
     assert result == sorted(expected_result)
 
 
-def test_cloud_glob_follows_symlinked_directories(tmp_path: pathlib.Path):
+@pytest.mark.parametrize(
+    "input_kind, pattern, filter_to_files",
+    [
+        ("path", "**/*.csv", False),
+        ("str", "**/*.csv", False),
+        # ``**/*`` also yields directories, so filter to files before comparing.
+        ("path", "**/*", True),
+        ("str", "**/*", True),
+    ],
+)
+def test_cloud_glob_follows_symlinked_directories(
+    tmp_path: pathlib.Path,
+    input_kind: str,
+    pattern: str,
+    filter_to_files: bool,
+):
     """
     Regression test for https://github.com/cytomining/CytoTable/issues/440.
 
     Per-site CSVs live in a real directory and are exposed under a separate
-    parent through a symlinked subdirectory. cloud_glob must discover the CSVs
-    via the symlinked path.
+    parent through a symlinked subdirectory. cloud_glob must discover the
+    CSVs via the symlinked path for both ``Path`` and ``str`` inputs and
+    for both extension-anchored and unrestricted glob patterns.
     """
     real = tmp_path / "real" / "analysis"
     real.mkdir(parents=True)
@@ -280,39 +296,31 @@ def test_cloud_glob_follows_symlinked_directories(tmp_path: pathlib.Path):
     (staged / "analysis").symlink_to(real, target_is_directory=True)
 
     staged_root = tmp_path / "staged"
+    start = staged_root if input_kind == "path" else str(staged_root)
 
-    # Path input
-    path_results = sorted(
-        p.name for p in cloud_glob(start=staged_root, pattern="**/*.csv")
-    )
-    assert path_results == sorted(expected_names)
-
-    # str input (exercises the string-path branch)
-    str_results = sorted(
-        pathlib.Path(p).name
-        for p in cloud_glob(start=str(staged_root), pattern="**/*.csv")
-    )
-    assert str_results == sorted(expected_names)
-
-    # The unrestricted '**/*' wildcard also yields directories, so filter to
-    # files before asserting we recover the same CSV set.
-    all_path_results = sorted(
-        p.name
-        for p in cloud_glob(start=staged_root, pattern="**/*")
-        if pathlib.Path(p).is_file()
-    )
-    assert all_path_results == sorted(expected_names)
-
-    all_str_results = sorted(
-        pathlib.Path(p).name
-        for p in cloud_glob(start=str(staged_root), pattern="**/*")
-        if pathlib.Path(p).is_file()
-    )
-    assert all_str_results == sorted(expected_names)
+    results = cloud_glob(start=start, pattern=pattern)
+    if filter_to_files:
+        results = (p for p in results if pathlib.Path(p).is_file())
+    names = sorted(pathlib.Path(p).name for p in results)
+    assert names == sorted(expected_names)
 
 
+@pytest.mark.parametrize(
+    "pattern, expected",
+    [
+        # Anchored, no '**' anywhere -- only the top-level CSV under analysis/.
+        ("analysis/*.csv", ["analysis/Cells.csv"]),
+        # '**' in the middle of the pattern.
+        (
+            "analysis/**/*.csv",
+            ["analysis/Cells.csv", "analysis/nested/Cells.csv"],
+        ),
+    ],
+)
 def test_cloud_glob_supports_non_double_star_prefixed_patterns(
     tmp_path: pathlib.Path,
+    pattern: str,
+    expected: List[str],
 ):
     """
     cloud_glob must honour pathlib-glob semantics for patterns that do not
@@ -331,19 +339,11 @@ def test_cloud_glob_supports_non_double_star_prefixed_patterns(
     staged.mkdir()
     (staged / "analysis").symlink_to(real, target_is_directory=True)
 
-    # Anchored, no '**' anywhere — only the top-level CSV under analysis/.
-    anchored = sorted(
+    results = sorted(
         str(p.relative_to(staged))
-        for p in cloud_glob(start=staged, pattern="analysis/*.csv")
+        for p in cloud_glob(start=staged, pattern=pattern)
     )
-    assert anchored == ["analysis/Cells.csv"]
-
-    # '**' in the middle of the pattern.
-    mid_double_star = sorted(
-        str(p.relative_to(staged))
-        for p in cloud_glob(start=staged, pattern="analysis/**/*.csv")
-    )
-    assert mid_double_star == ["analysis/Cells.csv", "analysis/nested/Cells.csv"]
+    assert results == expected
 
 
 def test_cloud_glob_deduplicates_paths_with_same_real_target(


### PR DESCRIPTION
## Summary

`cytotable.convert()` was silently raising `NoInputDataException` whenever its input directory contained data reachable only through a symlinked subdirectory — the default layout produced by Nextflow's `stageInMode='symlink'`. Root cause: `pathlib.Path.glob` does not follow directory symlinks before Python 3.13.

This PR adds a small `_glob_follow_symlinks(start, pattern)` helper and uses it in the local-path branches of `cloud_glob`. On Python 3.13+ it delegates to `Path.glob(pattern, recurse_symlinks=True)`. On 3.10–3.12 it walks the tree with `os.walk(..., followlinks=True)` and applies the post-`**/` portion of the pattern at each visited directory, which covers the patterns `cloud_glob` actually uses (`**/*`, `**/*.csv`, etc.).

The non-S3 `CloudPath` branch is left alone — real cloud providers don't have filesystem-level symlinks, and `cloudpathlib.CloudPath.glob` doesn't accept `recurse_symlinks` anyway.

Fixes #440.

## Test plan

- [x] New regression test `tests/test_utils.py::test_cloud_glob_follows_symlinked_directories` builds the staged-symlink layout from the issue and asserts `cloud_glob` returns the four CSVs for both `Path` and `str` inputs. Confirmed it fails before the helper change and passes after.
- [x] All existing `tests/test_utils.py` and `tests/test_sources.py` tests still pass (17 passed locally on Python 3.12.7).
- [x] Re-ran the issue's exact reproduction against `_get_source_filepaths`: `staged (symlinked subdir)` now returns 4 files (was raising `NoInputDataException`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem globbing: now follows symlinked directories, deduplicates identical targets reachable via multiple symlinks, and prevents infinite traversal on cyclic symlinks; preserves expected glob semantics for anchored and mid-pattern usage.

* **Tests**
  * Added regression tests covering symlink traversal, anchored and mid-pattern glob semantics, deduplication, and cycle termination.

* **Chores**
  * Bumped the mypy pre-commit hook to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->