### PR TITLE
Fix concurrent staging-dir cleanup races in parquet export

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -19,6 +19,7 @@ from cytotable.utils import (
     _default_parsl_config,
     _expand_path,
     _parsl_loaded,
+    _remove_empty_dirs,
     evaluate_futures,
 )
 from cytotable.validation import validate_convert_backend_options
@@ -590,12 +591,8 @@ def _expose_source_pageset_path(
         str:
             User-facing output filepath.
 
-    Raises:
-        OSError:
-            If cleanup fails for a reason other than a non-empty directory.
     """
 
-    import errno
     import pathlib
     import shutil
 
@@ -627,15 +624,10 @@ def _expose_source_pageset_path(
     exposed_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(internal_path), str(exposed_path))
 
-    # clean up the per-source hash dir and its parent if empty
-    for cleanup_dir in (internal_path.parent, internal_path.parent.parent):
-        try:
-            cleanup_dir.rmdir()
-        except OSError as os_err:
-            if os_err.errno != errno.ENOTEMPTY:
-                raise
-            break
-
+    # Intermediate staging dirs (the per-source hash dir and its parent) are
+    # removed in a single pass once all moves complete; see _remove_empty_dirs
+    # called from _run_export_workflow. Cleaning up there (single-threaded)
+    # avoids races between concurrent per-chunk tasks. See cytomining/CytoTable#442.
     return str(exposed_path)
 
 
@@ -846,12 +838,8 @@ def _concat_source_group(
         SchemaException:
             Raised when source files cannot be unified under a common schema
             during concatenation.
-        OSError:
-            Re-raised when cleaning up the source-group directory fails
-            with an errno other than ``ENOTEMPTY``.
     """
 
-    import errno
     import pathlib
 
     import pyarrow as pa
@@ -930,16 +918,10 @@ def _concat_source_group(
                 # remove the file which was written in the concatted parquet file (we no longer need it)
                 pathlib.Path(table).unlink()
 
-            # clean up the per-source hash dir and its parent if empty
-            chunk_parent = pathlib.Path(source["table"][0]).parent
-            for cleanup_dir in (chunk_parent, chunk_parent.parent):
-                try:
-                    cleanup_dir.rmdir()
-                except OSError as os_err:
-                    if os_err.errno != errno.ENOTEMPTY:
-                        raise
-                    break
-
+    # Intermediate staging dirs (per-source hash dirs and their parents) left
+    # behind after the chunk files above are unlinked are removed in a single
+    # pass after all work completes; see _remove_empty_dirs in
+    # _run_export_workflow. See cytomining/CytoTable#442.
     # return the concatted parquet filename
     concatted[0]["table"] = [destination_path]
 
@@ -1630,10 +1612,21 @@ def _run_export_workflow(  # pylint: disable=too-many-arguments, too-many-locals
             )
         else:
             # else we leave the joined chunks as-is and return them
-            return evaluate_futures(join_sources_result)
+            joined_results = evaluate_futures(join_sources_result)
+            # clean up empty intermediate staging dirs (single-threaded here)
+            _remove_empty_dirs(expanded_dest_path)
+            return joined_results
 
-    # wrap the final result as a future and return
-    return evaluate_futures(results)
+    # evaluate remaining futures so all intermediate file moves complete
+    final_results = evaluate_futures(results)
+
+    # Remove empty intermediate staging dirs left behind once chunked output has
+    # been moved/concatenated to its final location. Done here in a single pass
+    # (single-threaded) to avoid races between concurrent per-chunk cleanup
+    # tasks. See cytomining/CytoTable#442.
+    _remove_empty_dirs(expanded_dest_path)
+
+    return final_results
 
 
 def convert(  # pylint: disable=too-many-arguments,too-many-locals

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -653,6 +653,44 @@ def evaluate_futures(
     )
 
 
+def _remove_empty_dirs(path: Union[str, pathlib.Path]) -> None:
+    """
+    Recursively remove empty directories beneath ``path`` (bottom-up).
+
+    Used to clean up intermediate staging directories left behind after chunked
+    parquet output has been moved or concatenated to its final location. Only
+    empty directories are removed, so output files (and any directory that still
+    contains them) are preserved. ``path`` itself is always left in place, and
+    a non-existent or non-directory ``path`` is a no-op.
+
+    Performing this cleanup once, after all Parsl tasks have completed, avoids
+    races between concurrent per-chunk tasks which previously removed shared
+    staging directories while sibling tasks were still writing into them
+    (see cytomining/CytoTable#442).
+
+    Args:
+        path (Union[str, pathlib.Path]):
+            Root directory to sweep for empty subdirectories.
+    """
+
+    root = pathlib.Path(path)
+    if not root.is_dir():
+        return
+
+    # Walk bottom-up so child directories are removed before their parents,
+    # letting a parent become empty and be removed within the same pass.
+    for current_dir, _dirs, _files in os.walk(root, topdown=False):
+        directory = pathlib.Path(current_dir)
+        # never remove the provided root itself, only its empty descendants
+        if directory == root:
+            continue
+        try:
+            directory.rmdir()
+        except OSError:
+            # directory still holds output (or was already removed); leave it
+            pass
+
+
 def _generate_pagesets(
     keys: List[Union[int, float]], chunk_size: int
 ) -> List[Tuple[Union[int, float], Union[int, float]]]:

--- a/tests/test_convert_threaded.py
+++ b/tests/test_convert_threaded.py
@@ -22,8 +22,15 @@ from cytotable.convert import convert
 from cytotable.sources import _get_source_filepaths
 
 
-def _empty_dirs(root: pathlib.Path) -> List[str]:
-    # return string paths of empty directories anywhere under root
+def _find_empty_directory_paths(root: pathlib.Path) -> List[str]:
+    """Find empty directories for staging-cleanup test assertions.
+
+    Args:
+        root (pathlib.Path): Root directory to search recursively.
+
+    Returns:
+        List[str]: String paths for every empty directory below ``root``.
+    """
     return [
         str(path)
         for path in root.rglob("*")
@@ -620,8 +627,8 @@ def test_convert_multi_pageset_staging_cleanup(
 
     # the end-of-run cleanup sweep should leave no empty directories behind
     assert (
-        _empty_dirs(dest_path) == []
-    ), f"unexpected empty staging dirs (concat=False): {_empty_dirs(dest_path)}"
+        _find_empty_directory_paths(dest_path) == []
+    ), f"unexpected empty staging dirs (concat=False): {_find_empty_directory_paths(dest_path)}"
 
     # cleanup timing also changed for the concat path (_concat_source_group no
     # longer cleans up per-chunk), so verify the same multi-source, multi-pageset
@@ -639,5 +646,5 @@ def test_convert_multi_pageset_staging_cleanup(
         join=False,
     )
     assert (
-        _empty_dirs(concat_dest_path) == []
-    ), f"unexpected empty staging dirs (concat=True): {_empty_dirs(concat_dest_path)}"
+        _find_empty_directory_paths(concat_dest_path) == []
+    ), f"unexpected empty staging dirs (concat=True): {_find_empty_directory_paths(concat_dest_path)}"

--- a/tests/test_convert_threaded.py
+++ b/tests/test_convert_threaded.py
@@ -22,6 +22,15 @@ from cytotable.convert import convert
 from cytotable.sources import _get_source_filepaths
 
 
+def _empty_dirs(root: pathlib.Path) -> List[str]:
+    # return string paths of empty directories anywhere under root
+    return [
+        str(path)
+        for path in root.rglob("*")
+        if path.is_dir() and not any(path.iterdir())
+    ]
+
+
 def test_convert_tpe_cellprofiler_csv(
     load_parsl_threaded: None,
     fx_tempdir: str,
@@ -542,3 +551,93 @@ def test_convert_multi_source_colliding_parent_dir_names(
             f"{compartment}: expected 3x single-site rows ({3 * single_rows}),"
             f" got {multi_rows}"
         )
+
+
+def test_convert_multi_pageset_staging_cleanup(
+    load_parsl_threaded: None,
+    fx_tempdir: str,
+    data_dir_cellprofiler: str,
+):
+    """
+    Regression test for the staging-dir cleanup race (cytomining/CytoTable#442).
+
+    Sources split into multiple pagesets share an intermediate staging dir, and
+    per-chunk cleanup used to run concurrently -- racing both other cleanups and
+    sibling writers. Cleanup now happens once, after all moves complete, via
+    _remove_empty_dirs. This converts a multi-source, multi-pageset dataset and
+    asserts it succeeds, that chunking actually occurred, and that no empty
+    staging directories are left behind under the destination.
+    """
+
+    src_root = pathlib.Path(fx_tempdir) / "analyses"
+    for site in ("1", "2", "3"):
+        site_dir = src_root / site / "analysis"
+        site_dir.mkdir(parents=True, exist_ok=True)
+        for table_name in ("Cells.csv", "Cytoplasm.csv", "Nuclei.csv", "Image.csv"):
+            shutil.copy(
+                f"{data_dir_cellprofiler}/ExampleHuman/{table_name}",
+                site_dir / table_name,
+            )
+
+    dest_path = pathlib.Path(fx_tempdir) / "multi_pageset.parquet"
+    result = convert(
+        source_path=str(src_root),
+        dest_path=str(dest_path),
+        dest_datatype="parquet",
+        preset="cellprofiler_csv",
+        # small chunk size forces multiple pagesets per source, so multiple
+        # chunks share a single staging dir (exercising the cleanup path)
+        chunk_size=100,
+        concat=False,
+        join=False,
+    )
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {
+        "Cells.csv",
+        "Cytoplasm.csv",
+        "Nuclei.csv",
+        "Image.csv",
+    }
+
+    # every returned chunk is a real parquet file under the source-aligned layout
+    for source_results in result.values():
+        for source_result in source_results:
+            for table_path in source_result["table"]:
+                chunk_path = pathlib.Path(table_path)
+                assert chunk_path.is_file()
+                assert chunk_path.parent.name == "analysis"
+                assert chunk_path.parent.parent.name in {"1", "2", "3"}
+
+    # chunking actually happened: the larger compartments split into multiple
+    # pagesets per source, and each chunk respects the requested chunk size
+    for source_result in result["Cells.csv"]:
+        chunk_rows = [
+            parquet.read_table(source=table_path).num_rows
+            for table_path in source_result["table"]
+        ]
+        assert len(chunk_rows) > 1, "expected Cells.csv to split into multiple pagesets"
+        assert all(0 < num_rows <= 100 for num_rows in chunk_rows)
+
+    # the end-of-run cleanup sweep should leave no empty directories behind
+    assert (
+        _empty_dirs(dest_path) == []
+    ), f"unexpected empty staging dirs (concat=False): {_empty_dirs(dest_path)}"
+
+    # cleanup timing also changed for the concat path (_concat_source_group no
+    # longer cleans up per-chunk), so verify the same multi-source, multi-pageset
+    # input leaves no empty staging dirs there either. (concat=True with join=True
+    # is not checked here: _concat_join_sources rmtree's the whole intermediate
+    # tree and writes a single file, so the sweep is a no-op for that combo.)
+    concat_dest_path = pathlib.Path(fx_tempdir) / "multi_pageset_concat.parquet"
+    convert(
+        source_path=str(src_root),
+        dest_path=str(concat_dest_path),
+        dest_datatype="parquet",
+        preset="cellprofiler_csv",
+        chunk_size=100,
+        concat=True,
+        join=False,
+    )
+    assert (
+        _empty_dirs(concat_dest_path) == []
+    ), f"unexpected empty staging dirs (concat=True): {_empty_dirs(concat_dest_path)}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,10 +15,58 @@ from botocore.exceptions import EndpointConnectionError
 from cytotable.utils import (
     _generate_pagesets,
     _natural_sort,
+    _remove_empty_dirs,
     cloud_glob,
     find_anndata_metadata_field_names,
     map_pyarrow_type,
 )
+
+
+def test_remove_empty_dirs(tmp_path: pathlib.Path):
+    """
+    Test that _remove_empty_dirs removes empty subdirectories bottom-up while
+    preserving the root and any directory that still contains files.
+    """
+
+    # nested empty dirs which should be fully removed
+    (tmp_path / "a" / "b" / "c").mkdir(parents=True)
+    # a sibling empty dir which should be removed
+    (tmp_path / "empty").mkdir()
+    # a dir directly containing a file which should be preserved
+    (tmp_path / "keep").mkdir()
+    kept_file = tmp_path / "keep" / "data.txt"
+    kept_file.write_text("x")
+    # a dir whose only content is a nested file: both levels preserved
+    (tmp_path / "outer" / "inner").mkdir(parents=True)
+    nested_file = tmp_path / "outer" / "inner" / "data.txt"
+    nested_file.write_text("y")
+
+    _remove_empty_dirs(tmp_path)
+
+    # the root itself is always preserved
+    assert tmp_path.is_dir()
+    # empty trees are removed entirely
+    assert not (tmp_path / "a").exists()
+    assert not (tmp_path / "empty").exists()
+    # dirs holding files (directly or nested) are preserved
+    assert kept_file.is_file()
+    assert nested_file.is_file()
+    assert (tmp_path / "outer" / "inner").is_dir()
+
+
+def test_remove_empty_dirs_noop_for_missing_or_file(tmp_path: pathlib.Path):
+    """
+    Test that _remove_empty_dirs is a no-op for non-existent paths and files.
+    """
+
+    # a non-existent path does not raise
+    _remove_empty_dirs(tmp_path / "does-not-exist")
+
+    # a file path does not raise and the file is left intact
+    a_file = tmp_path / "a_file.txt"
+    a_file.write_text("x")
+    _remove_empty_dirs(a_file)
+    assert a_file.is_file()
 
 
 def test_generate_pageset():  # pylint: disable=too-many-statements


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

During chunked parquet export, each task removed its staging directory as soon as it finished. Those directories are shared across concurrent Parsl tasks, so this could race two ways: two tasks might try to remove the same directory (and the one that lost the race hit a `FileNotFoundError`), or one task might remove a directory while another was still writing a chunk into it.

This drops the per-chunk cleanup from `_expose_source_pageset_path` and `_concat_source_group`. Instead, empty staging directories are removed in a single pass at the end of `_run_export_workflow`, once all the file moves are done. That runs single-threaded and only removes empty directories, so there's nothing left to race against and real output is never touched.

It also adds unit tests for the new sweep plus a multi-pageset conversion test that checks no empty directories are left behind.

This is a follow-up to the cleanup logic added in cytomining/CytoTable#444 (which fixed cytomining/CytoTable#442), and it resolves the flaky `test_convert_multi_source_colliding_parent_dir_names`.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of intermediate staging directories during export by consolidating empty-directory removal into a single, deterministic step to avoid race conditions.

* **Tests**
  * Added unit tests for the new empty-directory cleanup utility, including no-op behavior for missing paths and file inputs.
  * Added an export workflow test to verify chunking output and ensure no empty intermediate destination directories remain for both `concat=False` and `concat=True`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->