### PR TITLE
Parallelize iceberg image crop export across worker processes

### DIFF
--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1656,6 +1656,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
     sort_output: bool = True,
     preset: Optional[str] = "cellprofiler_csv",
     parsl_config: Optional[parsl.Config] = None,
+    image_crop_workers: Optional[int] = None,
     **kwargs,
 ) -> Union[Dict[str, List[Dict[str, Any]]], List[Any], str]:
     """
@@ -1766,6 +1767,15 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             Optional Parsl configuration to use for running CytoTable operations.
             Note: when using CytoTable multiple times in the same process,
             CytoTable will use the first provided configuration for all runs.
+        image_crop_workers (Optional[int]):
+            Number of worker processes used to parallelize the per-row image
+            crop work within each chunk when exporting to an Iceberg warehouse
+            (requires ``dest_backend="iceberg"`` and ``image_dir``). ``None``
+            (default) selects an automatic count (capped at 8); ``0`` or ``1``
+            keeps the serial path. The crop work holds the GIL, so this uses
+            processes rather than threads; small chunks stay serial
+            automatically. Lower this for multi-chunk plates to avoid
+            oversubscribing cores.
         **kwargs:
             Additional keyword args forwarded to source-gathering and
             backend-specific writers (for example, Cloudpathlib client
@@ -1860,6 +1870,7 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             preset=preset,
             drop_null=drop_null,
             parsl_config=parsl_config,
+            image_crop_workers=image_crop_workers,
             **kwargs,
         )
 

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1775,7 +1775,12 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             keeps the serial path. The crop work holds the GIL, so this uses
             processes rather than threads; small chunks stay serial
             automatically. Lower this for multi-chunk plates to avoid
-            oversubscribing cores.
+            oversubscribing cores. The parallel path uses the ``spawn`` start
+            method, which re-imports the caller's top-level script as
+            ``__main__`` in each worker: when calling ``convert(...)`` from a
+            plain script, guard that call with ``if __name__ == "__main__":`` so
+            workers do not re-run your whole pipeline (notebooks and REPLs are
+            unaffected), or set ``image_crop_workers=1`` to use the serial path.
         **kwargs:
             Additional keyword args forwarded to source-gathering and
             backend-specific writers (for example, Cloudpathlib client

--- a/cytotable/convert.py
+++ b/cytotable/convert.py
@@ -1774,8 +1774,12 @@ def convert(  # pylint: disable=too-many-arguments,too-many-locals
             (default) selects an automatic count (capped at 8); ``0`` or ``1``
             keeps the serial path. The crop work holds the GIL, so this uses
             processes rather than threads; small chunks stay serial
-            automatically. Lower this for multi-chunk plates to avoid
-            oversubscribing cores. The parallel path uses the ``spawn`` start
+            automatically. This is *per chunk*: CytoTable also runs chunks
+            concurrently through a Parsl thread pool (default 4 threads), so a
+            multi-chunk plate can run up to ``4 x image_crop_workers`` crop
+            processes at once (up to 32 with the defaults) — lower this for
+            multi-chunk plates to avoid oversubscribing cores. The parallel path
+            uses the ``spawn`` start
             method, which re-imports the caller's top-level script as
             ``__main__`` in each worker: when calling ``convert(...)`` from a
             plain script, guard that call with ``if __name__ == "__main__":`` so

--- a/cytotable/warehouse/iceberg.py
+++ b/cytotable/warehouse/iceberg.py
@@ -656,7 +656,12 @@ def write_iceberg_warehouse(  # noqa: PLR0913
             (``slice_ome_arrow`` over a pyarrow struct) holds the GIL, so
             threads do not help. Small chunks stay serial automatically. For
             multi-chunk plates, lower this value to avoid oversubscribing
-            cores (each chunk's task spawns its own pool).
+            cores (each chunk's task spawns its own pool). The parallel path
+            uses the ``spawn`` start method, which re-imports the caller's
+            top-level script as ``__main__`` in each worker: callers that invoke
+            ``convert(...)`` from a plain script must guard that call with
+            ``if __name__ == "__main__":`` (notebooks and REPLs are unaffected),
+            or set ``image_crop_workers=1`` to use the serial path.
         default_namespace (str):
             Iceberg namespace under which the profiles table is registered.
         images_namespace (str):

--- a/cytotable/warehouse/iceberg.py
+++ b/cytotable/warehouse/iceberg.py
@@ -52,6 +52,7 @@ def _image_crop_table_app(
     bbox_column_map: "Optional[Dict[str, str]]" = None,
     segmentation_file_regex: "Optional[Dict[str, str]]" = None,
     path_kwargs: "Optional[Dict[str, Any]]" = None,
+    image_crop_workers: "Optional[int]" = None,
 ) -> "pa.Table":
     """Parsl thread-pool wrapper for image_crop_table_from_joined_chunk."""
     from cytotable.warehouse.images import image_crop_table_from_joined_chunk
@@ -64,6 +65,7 @@ def _image_crop_table_app(
         bbox_column_map=bbox_column_map,
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
+        crop_workers=image_crop_workers,
     )
 
 
@@ -75,6 +77,7 @@ def _source_image_table_app(
     outline_dir: "Optional[str]" = None,
     segmentation_file_regex: "Optional[Dict[str, str]]" = None,
     path_kwargs: "Optional[Dict[str, Any]]" = None,
+    image_crop_workers: "Optional[int]" = None,
 ) -> "pa.Table":
     """Parsl thread-pool wrapper for source_image_table_from_joined_chunk."""
     from cytotable.warehouse.images import source_image_table_from_joined_chunk
@@ -86,6 +89,7 @@ def _source_image_table_app(
         outline_dir=outline_dir,
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
+        crop_workers=image_crop_workers,
     )
 
 
@@ -581,6 +585,7 @@ def write_iceberg_warehouse(  # noqa: PLR0913
     bbox_column_map: Optional[Dict[str, str]] = None,
     segmentation_file_regex: Optional[Dict[str, str]] = None,
     include_source_images: bool = False,
+    image_crop_workers: Optional[int] = None,
     default_namespace: str = DEFAULT_NAMESPACE,
     images_namespace: str = DEFAULT_IMAGES_NAMESPACE,
     registry_file: str = DEFAULT_REGISTRY_FILE,
@@ -643,6 +648,15 @@ def write_iceberg_warehouse(  # noqa: PLR0913
             See :func:`cytotable.convert.convert`.
         include_source_images (bool):
             See :func:`cytotable.convert.convert`.
+        image_crop_workers (Optional[int]):
+            Number of worker processes used to parallelize the per-row image
+            crop work *within* each chunk. ``None`` (default) selects an
+            automatic count (capped at 8); ``0`` or ``1`` keeps the serial
+            path. Parallelism uses a process pool because the crop work
+            (``slice_ome_arrow`` over a pyarrow struct) holds the GIL, so
+            threads do not help. Small chunks stay serial automatically. For
+            multi-chunk plates, lower this value to avoid oversubscribing
+            cores (each chunk's task spawns its own pool).
         default_namespace (str):
             Iceberg namespace under which the profiles table is registered.
         images_namespace (str):
@@ -889,6 +903,7 @@ def write_iceberg_warehouse(  # noqa: PLR0913
                         bbox_column_map=bbox_column_map,
                         segmentation_file_regex=segmentation_file_regex,
                         path_kwargs=kwargs,
+                        image_crop_workers=image_crop_workers,
                     )
                     for chunk_path in joined_chunk_paths
                 ]
@@ -901,6 +916,7 @@ def write_iceberg_warehouse(  # noqa: PLR0913
                             outline_dir=outline_dir,
                             segmentation_file_regex=segmentation_file_regex,
                             path_kwargs=kwargs,
+                            image_crop_workers=image_crop_workers,
                         )
                         for chunk_path in joined_chunk_paths
                     ]
@@ -923,6 +939,7 @@ def write_iceberg_warehouse(  # noqa: PLR0913
                         bbox_column_map=bbox_column_map,
                         segmentation_file_regex=segmentation_file_regex,
                         path_kwargs=kwargs,
+                        crop_workers=image_crop_workers,
                     )
                 )
                 if crop_table.num_rows == 0:
@@ -950,6 +967,7 @@ def write_iceberg_warehouse(  # noqa: PLR0913
                             outline_dir=outline_dir,
                             segmentation_file_regex=segmentation_file_regex,
                             path_kwargs=kwargs,
+                            crop_workers=image_crop_workers,
                         )
                     )
                     if source_image_table.num_rows != 0:

--- a/cytotable/warehouse/iceberg.py
+++ b/cytotable/warehouse/iceberg.py
@@ -654,10 +654,13 @@ def write_iceberg_warehouse(  # noqa: PLR0913
             automatic count (capped at 8); ``0`` or ``1`` keeps the serial
             path. Parallelism uses a process pool because the crop work
             (``slice_ome_arrow`` over a pyarrow struct) holds the GIL, so
-            threads do not help. Small chunks stay serial automatically. For
-            multi-chunk plates, lower this value to avoid oversubscribing
-            cores (each chunk's task spawns its own pool). The parallel path
-            uses the ``spawn`` start method, which re-imports the caller's
+            threads do not help. Small chunks stay serial automatically. This
+            is *per chunk*: CytoTable also runs chunks concurrently through a
+            Parsl thread pool (default 4 threads), so a multi-chunk plate can
+            run up to ``4 x image_crop_workers`` crop processes at once (up to
+            32 with the defaults) — lower this value for multi-chunk plates to
+            avoid oversubscribing cores. The parallel path uses the ``spawn``
+            start method, which re-imports the caller's
             top-level script as ``__main__`` in each worker: callers that invoke
             ``convert(...)`` from a plain script must guard that call with
             ``if __name__ == "__main__":`` (notebooks and REPLs are unaffected),

--- a/cytotable/warehouse/images.py
+++ b/cytotable/warehouse/images.py
@@ -5,9 +5,13 @@ Helpers for exporting image crops alongside CytoTable measurement data.
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
 import re
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
+from functools import partial
 from json import dumps
 from typing import Any, Dict, Optional, Sequence, Union
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
@@ -647,37 +651,46 @@ def _validated_bbox_values(
     }
 
 
-def image_crop_table_from_joined_chunk(
-    chunk_path: str,
-    image_dir: str,
-    mask_dir: Optional[str] = None,
-    outline_dir: Optional[str] = None,
-    bbox_column_map: Optional[Dict[str, str]] = None,
-    segmentation_file_regex: Optional[Dict[str, str]] = None,
-    path_kwargs: Optional[Dict[str, Any]] = None,
-) -> pa.Table:
+# Minimum estimated crop count before the per-chunk ProcessPool path is used.
+# Below this the spawn overhead dominates, so the serial path is kept (this also
+# keeps the existing small-chunk tests ProcessPool-free and deterministic).
+_CROP_PARALLEL_MIN = 64
+
+
+def _resolve_image_worker_count(crop_workers: Optional[int]) -> int:
     """
-    Build an Arrow table of OME-Arrow image crops from one joined parquet chunk.
+    Resolve the number of worker processes for per-chunk image cropping.
+
+    ``None`` selects an automatic count (capped at 8); ``0`` or ``1`` forces the
+    serial path. Negative values are clamped to 1.
     """
 
-    _, ome_arrow_struct = _require_ome_arrow()
-    ome_arrow_struct = _strip_null_fields_from_type(ome_arrow_struct)
-    data = parquet.read_table(chunk_path).to_pandas()
-    image_columns = _resolve_image_columns(data)
-    bbox_columns = resolve_bbox_columns(
-        data.columns.tolist(), bbox_column_map=bbox_column_map
-    )
+    if crop_workers is None:
+        return min(os.cpu_count() or 4, 8)
+    return max(1, int(crop_workers))
 
-    if bbox_columns is None:
-        raise ValueError(
-            "Unable to identify bounding box coordinate columns for image export."
-        )
 
-    image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
-    mask_index = _build_file_index(mask_dir, path_kwargs=path_kwargs)
-    outline_index = _build_file_index(outline_dir, path_kwargs=path_kwargs)
+def _collect_crop_rows(
+    data: pd.DataFrame,
+    image_columns: Sequence[str],
+    bbox_columns: BBoxColumns,
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_index: FileIndex,
+    mask_index: FileIndex,
+    outline_index: FileIndex,
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Build the list of crop-row records for one joined chunk.
+
+    Pure with respect to ``data`` and the provided indexes, so it may run inside
+    a worker process.
+    """
+
     segmentation_cache: dict[str, Optional[ImagePath]] = {}
-
     rows: list[dict[str, Any]] = []
     for _, row in data.iterrows():
         bbox_values = _validated_bbox_values(row, bbox_columns)
@@ -758,6 +771,17 @@ def image_crop_table_from_joined_chunk(
                 ),
             }
             rows.append(record)
+
+    return rows
+
+
+def _rows_to_crop_table(
+    rows: list[dict[str, Any]],
+    ome_arrow_struct: pa.DataType,
+) -> pa.Table:
+    """
+    Assemble crop-row records into an Arrow table.
+    """
 
     key_field_names = sorted(
         {key for row in rows for key in row.keys()}
@@ -867,26 +891,219 @@ def image_crop_table_from_joined_chunk(
     return pa.table({**key_columns, **fixed_columns})
 
 
-def source_image_table_from_joined_chunk(
+def _crop_shard_worker(
     chunk_path: str,
-    image_dir: str,
-    mask_dir: Optional[str] = None,
-    outline_dir: Optional[str] = None,
-    segmentation_file_regex: Optional[Dict[str, str]] = None,
-    path_kwargs: Optional[Dict[str, Any]] = None,
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_columns: Sequence[str],
+    bbox_columns: BBoxColumns,
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
 ) -> pa.Table:
     """
-    Build an Arrow table of full OME-Arrow source images from one joined chunk.
+    Process one row-shard of a joined chunk in a worker process.
+
+    Module-level so it is importable under multiprocessing spawn. Rebuilds the
+    file indexes locally (a few cheap dir walks) to avoid serializing
+    ``CloudPath`` objects across the process boundary.
     """
 
     _, ome_arrow_struct = _require_ome_arrow()
     ome_arrow_struct = _strip_null_fields_from_type(ome_arrow_struct)
     data = parquet.read_table(chunk_path).to_pandas()
+    image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
+    mask_index = _build_file_index(mask_dir, path_kwargs=path_kwargs)
+    outline_index = _build_file_index(outline_dir, path_kwargs=path_kwargs)
+    rows = _collect_crop_rows(
+        data=data,
+        image_columns=image_columns,
+        bbox_columns=bbox_columns,
+        image_dir=image_dir,
+        mask_dir=mask_dir,
+        outline_dir=outline_dir,
+        image_index=image_index,
+        mask_index=mask_index,
+        outline_index=outline_index,
+        segmentation_file_regex=segmentation_file_regex,
+        path_kwargs=path_kwargs,
+    )
+    return _rows_to_crop_table(rows, ome_arrow_struct)
+
+
+def _write_row_shards(table: pa.Table, n_shards: int, tmpdir: str) -> list[str]:
+    """
+    Split an Arrow table into ``n_shards`` contiguous row-shard parquet files.
+
+    Shard boundaries are contiguous and ordered so concatenating the per-shard
+    results reproduces the serial row order.
+    """
+
+    n = table.num_rows
+    shard_size = max(1, n // n_shards)
+    shard_paths: list[str] = []
+    for i in range(n_shards):
+        start = i * shard_size
+        end = (i + 1) * shard_size if i < n_shards - 1 else n
+        if start >= end:
+            break
+        shard_path = os.path.join(tmpdir, f"shard_{i}.parquet")
+        parquet.write_table(table.slice(start, end - start), shard_path)
+        shard_paths.append(shard_path)
+    return shard_paths
+
+
+def _image_crop_table_parallel(
+    table: pa.Table,
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_columns: Sequence[str],
+    bbox_columns: BBoxColumns,
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
+    workers: int,
+) -> pa.Table:
+    """
+    Run the per-row crop work across ``workers`` processes and merge results.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="cytotable_crop_shards_") as tmpdir:
+        shard_paths = _write_row_shards(table, workers, tmpdir)
+        worker = partial(
+            _crop_shard_worker,
+            image_dir=image_dir,
+            mask_dir=mask_dir,
+            outline_dir=outline_dir,
+            image_columns=list(image_columns),
+            bbox_columns=bbox_columns,
+            segmentation_file_regex=segmentation_file_regex,
+            path_kwargs=path_kwargs,
+        )
+        with ProcessPoolExecutor(max_workers=min(workers, len(shard_paths))) as ex:
+            shard_tables = list(ex.map(worker, shard_paths))
+    return pa.concat_tables(shard_tables)
+
+
+def image_crop_table_from_joined_chunk(
+    chunk_path: str,
+    image_dir: str,
+    mask_dir: Optional[str] = None,
+    outline_dir: Optional[str] = None,
+    bbox_column_map: Optional[Dict[str, str]] = None,
+    segmentation_file_regex: Optional[Dict[str, str]] = None,
+    path_kwargs: Optional[Dict[str, Any]] = None,
+    crop_workers: Optional[int] = None,
+) -> pa.Table:
+    """
+    Build an Arrow table of OME-Arrow image crops from one joined parquet chunk.
+
+    ``crop_workers`` controls per-chunk parallelism over the per-row crop loop:
+    ``None`` selects an automatic count (capped at 8), while ``0``/``1`` keeps
+    the serial path. Parallelism uses a process pool because the crop work
+    (``slice_ome_arrow`` over a pyarrow struct) holds the GIL, so threads do not
+    help. A threshold (``_CROP_PARALLEL_MIN``) keeps small chunks serial so the
+    process-spawn overhead never dominates.
+    """
+
+    _, ome_arrow_struct = _require_ome_arrow()
+    ome_arrow_struct = _strip_null_fields_from_type(ome_arrow_struct)
+    table = parquet.read_table(chunk_path)
+    data = table.to_pandas()
     image_columns = _resolve_image_columns(data)
+    bbox_columns = resolve_bbox_columns(
+        data.columns.tolist(), bbox_column_map=bbox_column_map
+    )
+
+    if bbox_columns is None:
+        raise ValueError(
+            "Unable to identify bounding box coordinate columns for image export."
+        )
+
+    workers = _resolve_image_worker_count(crop_workers)
+    estimated_crops = len(data) * max(1, len(image_columns))
+    if workers > 1 and estimated_crops >= _CROP_PARALLEL_MIN:
+        return _image_crop_table_parallel(
+            table=table,
+            image_dir=image_dir,
+            mask_dir=mask_dir,
+            outline_dir=outline_dir,
+            image_columns=image_columns,
+            bbox_columns=bbox_columns,
+            segmentation_file_regex=segmentation_file_regex,
+            path_kwargs=path_kwargs,
+            workers=workers,
+        )
 
     image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
     mask_index = _build_file_index(mask_dir, path_kwargs=path_kwargs)
     outline_index = _build_file_index(outline_dir, path_kwargs=path_kwargs)
+    rows = _collect_crop_rows(
+        data=data,
+        image_columns=image_columns,
+        bbox_columns=bbox_columns,
+        image_dir=image_dir,
+        mask_dir=mask_dir,
+        outline_dir=outline_dir,
+        image_index=image_index,
+        mask_index=mask_index,
+        outline_index=outline_index,
+        segmentation_file_regex=segmentation_file_regex,
+        path_kwargs=path_kwargs,
+    )
+    return _rows_to_crop_table(rows, ome_arrow_struct)
+
+
+# Minimum number of *unique* source images before the source-image ProcessPool
+# path is used. Source-image work is dominated by one full read per unique image
+# (rows are deduplicated by Metadata_ImageID), so the threshold is on unique
+# images rather than row count.
+_SOURCE_PARALLEL_MIN = 16
+
+
+def _dedup_table_by_first_occurrence(table: pa.Table, key_column: str) -> pa.Table:
+    """
+    Drop rows with a repeated ``key_column`` value, keeping the first occurrence.
+
+    Preserves row order and the table schema (including nested struct columns).
+    """
+
+    if table.num_rows == 0:
+        return table
+    keys = table.column(key_column).to_pylist()
+    seen: set[Any] = set()
+    indices: list[int] = []
+    for i, key in enumerate(keys):
+        if key is not None:
+            if key in seen:
+                continue
+            seen.add(key)
+        indices.append(i)
+    if len(indices) == table.num_rows:
+        return table
+    return table.take(indices)
+
+
+def _collect_source_rows(
+    data: pd.DataFrame,
+    image_columns: Sequence[str],
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_index: FileIndex,
+    mask_index: FileIndex,
+    outline_index: FileIndex,
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Build the deduplicated list of source-image rows for one joined chunk.
+
+    Rows are deduplicated by ``Metadata_ImageID`` (first occurrence wins), so a
+    shard returns at most one row per source image it touches. Pure with respect
+    to ``data`` and the provided indexes, so it may run in a worker process.
+    """
+
     segmentation_cache: dict[str, Optional[ImagePath]] = {}
     rows_by_id: dict[str, dict[str, Any]] = {}
 
@@ -953,7 +1170,17 @@ def source_image_table_from_joined_chunk(
                 ),
             }
 
-    rows = list(rows_by_id.values())
+    return list(rows_by_id.values())
+
+
+def _rows_to_source_table(
+    rows: list[dict[str, Any]],
+    ome_arrow_struct: pa.DataType,
+) -> pa.Table:
+    """
+    Assemble source-image rows into an Arrow table.
+    """
+
     key_field_names = sorted(
         {key for row in rows for key in row.keys()}
         - {
@@ -1035,6 +1262,152 @@ def source_image_table_from_joined_chunk(
         ),
     }
     return pa.table({**key_columns, **fixed_columns})
+
+
+def _source_shard_worker(
+    chunk_path: str,
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_columns: Sequence[str],
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
+) -> pa.Table:
+    """
+    Process one row-shard of a joined chunk for source-image export.
+
+    Module-level so it is importable under multiprocessing spawn. Rebuilds the
+    file indexes locally to avoid serializing ``CloudPath`` across the process
+    boundary.
+    """
+
+    _, ome_arrow_struct = _require_ome_arrow()
+    ome_arrow_struct = _strip_null_fields_from_type(ome_arrow_struct)
+    data = parquet.read_table(chunk_path).to_pandas()
+    image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
+    mask_index = _build_file_index(mask_dir, path_kwargs=path_kwargs)
+    outline_index = _build_file_index(outline_dir, path_kwargs=path_kwargs)
+    rows = _collect_source_rows(
+        data=data,
+        image_columns=image_columns,
+        image_dir=image_dir,
+        mask_dir=mask_dir,
+        outline_dir=outline_dir,
+        image_index=image_index,
+        mask_index=mask_index,
+        outline_index=outline_index,
+        segmentation_file_regex=segmentation_file_regex,
+        path_kwargs=path_kwargs,
+    )
+    return _rows_to_source_table(rows, ome_arrow_struct)
+
+
+def _source_image_table_parallel(
+    table: pa.Table,
+    image_dir: Optional[str],
+    mask_dir: Optional[str],
+    outline_dir: Optional[str],
+    image_columns: Sequence[str],
+    segmentation_file_regex: Optional[Dict[str, str]],
+    path_kwargs: Optional[Dict[str, Any]],
+    workers: int,
+) -> pa.Table:
+    """
+    Run source-image export across ``workers`` processes and merge results.
+
+    Each shard deduplicates internally by ``Metadata_ImageID``; the merged table
+    is deduplicated again across shards (first occurrence wins) so an image that
+    appears in more than one shard is exported exactly once.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="cytotable_source_shards_") as tmpdir:
+        shard_paths = _write_row_shards(table, workers, tmpdir)
+        worker = partial(
+            _source_shard_worker,
+            image_dir=image_dir,
+            mask_dir=mask_dir,
+            outline_dir=outline_dir,
+            image_columns=list(image_columns),
+            segmentation_file_regex=segmentation_file_regex,
+            path_kwargs=path_kwargs,
+        )
+        with ProcessPoolExecutor(max_workers=min(workers, len(shard_paths))) as ex:
+            shard_tables = list(ex.map(worker, shard_paths))
+    merged = pa.concat_tables(shard_tables)
+    return _dedup_table_by_first_occurrence(merged, "Metadata_ImageID")
+
+
+def _count_unique_source_image_names(
+    data: pd.DataFrame, image_columns: Sequence[str]
+) -> int:
+    """
+    Estimate the number of distinct source images referenced by a chunk.
+    """
+
+    names: set[str] = set()
+    for column in image_columns:
+        column_values = data[column].dropna().astype(str) if column in data else None
+        if column_values is not None and not column_values.empty:
+            names.update(column_values.unique().tolist())
+    return len(names)
+
+
+def source_image_table_from_joined_chunk(
+    chunk_path: str,
+    image_dir: str,
+    mask_dir: Optional[str] = None,
+    outline_dir: Optional[str] = None,
+    segmentation_file_regex: Optional[Dict[str, str]] = None,
+    path_kwargs: Optional[Dict[str, Any]] = None,
+    crop_workers: Optional[int] = None,
+) -> pa.Table:
+    """
+    Build an Arrow table of full OME-Arrow source images from one joined chunk.
+
+    ``crop_workers`` controls per-chunk parallelism over the per-image reads,
+    mirroring ``image_crop_table_from_joined_chunk``: ``None`` selects an
+    automatic count (capped at 8), ``0``/``1`` keeps the serial path. Because
+    source-image rows are deduplicated by ``Metadata_ImageID``, parallelism is
+    only used when the chunk references at least ``_SOURCE_PARALLEL_MIN``
+    distinct images.
+    """
+
+    _, ome_arrow_struct = _require_ome_arrow()
+    ome_arrow_struct = _strip_null_fields_from_type(ome_arrow_struct)
+    table = parquet.read_table(chunk_path)
+    data = table.to_pandas()
+    image_columns = _resolve_image_columns(data)
+
+    workers = _resolve_image_worker_count(crop_workers)
+    unique_image_count = _count_unique_source_image_names(data, image_columns)
+    if workers > 1 and unique_image_count >= _SOURCE_PARALLEL_MIN:
+        return _source_image_table_parallel(
+            table=table,
+            image_dir=image_dir,
+            mask_dir=mask_dir,
+            outline_dir=outline_dir,
+            image_columns=image_columns,
+            segmentation_file_regex=segmentation_file_regex,
+            path_kwargs=path_kwargs,
+            workers=workers,
+        )
+
+    image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
+    mask_index = _build_file_index(mask_dir, path_kwargs=path_kwargs)
+    outline_index = _build_file_index(outline_dir, path_kwargs=path_kwargs)
+    rows = _collect_source_rows(
+        data=data,
+        image_columns=image_columns,
+        image_dir=image_dir,
+        mask_dir=mask_dir,
+        outline_dir=outline_dir,
+        image_index=image_index,
+        mask_index=mask_index,
+        outline_index=outline_index,
+        segmentation_file_regex=segmentation_file_regex,
+        path_kwargs=path_kwargs,
+    )
+    return _rows_to_source_table(rows, ome_arrow_struct)
 
 
 def add_object_id_to_profiles_frame(

--- a/cytotable/warehouse/images.py
+++ b/cytotable/warehouse/images.py
@@ -737,12 +737,24 @@ def _resolve_image_worker_count(crop_workers: Optional[int]) -> int:
     """
     Resolve the number of worker processes for per-chunk image cropping.
 
-    ``None`` selects an automatic count (capped at 8); ``0`` or ``1`` forces the
-    serial path. Negative values are clamped to 1.
+    Selection policy:
+
+    - ``None`` (the default): pick an automatic count -- the number of logical
+      CPUs, falling back to 4 when :func:`os.cpu_count` cannot report it, and
+      capped at 8. The cap is the sweet spot for the GIL-bound crop slice work;
+      more processes just oversubscribe cores without speeding up the slice.
+    - An explicit integer: clamp it to at least 1. Values of ``0`` or less
+      resolve to ``1``, which keeps the serial path -- the caller only spawns a
+      process pool when this returns a value greater than 1 (see
+      ``_CROP_PARALLEL_MIN``), so ``0`` and ``1`` both mean "serial".
+
+    Returns the resolved worker count; the caller decides whether that is
+    enough to actually parallelize.
     """
 
     if crop_workers is None:
-        return min(os.cpu_count() or 4, 8)
+        cpu_count = os.cpu_count() or 4
+        return min(cpu_count, 8)
     return max(1, int(crop_workers))
 
 

--- a/cytotable/warehouse/images.py
+++ b/cytotable/warehouse/images.py
@@ -5,6 +5,7 @@ Helpers for exporting image crops alongside CytoTable measurement data.
 from __future__ import annotations
 
 import logging
+import multiprocessing
 import os
 import pathlib
 import re
@@ -516,6 +517,30 @@ def _extract_image_key_fields(row: pd.Series) -> dict[str, Any]:
     }
 
 
+def _extract_image_key_field_names(data: pd.DataFrame) -> list[str]:
+    """
+    Return the sorted image-level key field names present in a chunk.
+
+    Computed from the full chunk so every shard -- including ones that emit no
+    rows -- assembles a table with the same key columns, which is required for
+    ``pa.concat_tables`` to succeed across shards.
+    """
+
+    preferred_columns = [
+        "Metadata_TableNumber",
+        "Metadata_ImageNumber",
+        "Image_Metadata_Well",
+        "Image_Metadata_Plate",
+        "Metadata_Well",
+        "Metadata_Plate",
+    ]
+    return sorted(
+        column
+        for column in preferred_columns
+        if column in data.columns and not data[column].isna().all()
+    )
+
+
 def _build_stable_object_id(
     key_fields: dict[str, Any],
     bbox: Optional[dict[str, int]] = None,
@@ -778,29 +803,15 @@ def _collect_crop_rows(
 def _rows_to_crop_table(
     rows: list[dict[str, Any]],
     ome_arrow_struct: pa.DataType,
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Assemble crop-row records into an Arrow table.
-    """
 
-    key_field_names = sorted(
-        {key for row in rows for key in row.keys()}
-        - {
-            "source_image_column",
-            "source_image_file",
-            "label_source_kind",
-            "Metadata_ObjectID",
-            "Metadata_ImageCropID",
-            "source_bbox_x_min",
-            "source_bbox_x_max",
-            "source_bbox_y_min",
-            "source_bbox_y_max",
-            "ome_arrow_image",
-            "ome_arrow_outline",
-            "ome_arrow_mask",
-            "ome_arrow_label",
-        }
-    )
+    ``key_field_names`` is the full chunk's key field set (see
+    :func:`_extract_image_key_field_names`) so empty shard outputs carry the
+    same schema as non-empty siblings and concatenate cleanly.
+    """
 
     if not rows:
         return pa.table(
@@ -900,13 +911,16 @@ def _crop_shard_worker(
     bbox_columns: BBoxColumns,
     segmentation_file_regex: Optional[Dict[str, str]],
     path_kwargs: Optional[Dict[str, Any]],
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Process one row-shard of a joined chunk in a worker process.
 
     Module-level so it is importable under multiprocessing spawn. Rebuilds the
     file indexes locally (a few cheap dir walks) to avoid serializing
-    ``CloudPath`` objects across the process boundary.
+    ``CloudPath`` objects across the process boundary. ``key_field_names`` is
+    the full chunk's key field set, passed in so empty shards still emit the
+    complete schema.
     """
 
     _, ome_arrow_struct = _require_ome_arrow()
@@ -928,7 +942,7 @@ def _crop_shard_worker(
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
     )
-    return _rows_to_crop_table(rows, ome_arrow_struct)
+    return _rows_to_crop_table(rows, ome_arrow_struct, key_field_names)
 
 
 def _write_row_shards(table: pa.Table, n_shards: int, tmpdir: str) -> list[str]:
@@ -944,7 +958,7 @@ def _write_row_shards(table: pa.Table, n_shards: int, tmpdir: str) -> list[str]:
     shard_paths: list[str] = []
     for i in range(n_shards):
         start = i * shard_size
-        end = (i + 1) * shard_size if i < n_shards - 1 else n
+        end = min((i + 1) * shard_size, n) if i < n_shards - 1 else n
         if start >= end:
             break
         shard_path = os.path.join(tmpdir, f"shard_{i}.parquet")
@@ -963,6 +977,7 @@ def _image_crop_table_parallel(
     segmentation_file_regex: Optional[Dict[str, str]],
     path_kwargs: Optional[Dict[str, Any]],
     workers: int,
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Run the per-row crop work across ``workers`` processes and merge results.
@@ -979,8 +994,12 @@ def _image_crop_table_parallel(
             bbox_columns=bbox_columns,
             segmentation_file_regex=segmentation_file_regex,
             path_kwargs=path_kwargs,
+            key_field_names=list(key_field_names),
         )
-        with ProcessPoolExecutor(max_workers=min(workers, len(shard_paths))) as ex:
+        with ProcessPoolExecutor(
+            max_workers=min(workers, len(shard_paths)),
+            mp_context=multiprocessing.get_context("spawn"),
+        ) as ex:
             shard_tables = list(ex.map(worker, shard_paths))
     return pa.concat_tables(shard_tables)
 
@@ -1022,6 +1041,7 @@ def image_crop_table_from_joined_chunk(
 
     workers = _resolve_image_worker_count(crop_workers)
     estimated_crops = len(data) * max(1, len(image_columns))
+    key_field_names = _extract_image_key_field_names(data)
     if workers > 1 and estimated_crops >= _CROP_PARALLEL_MIN:
         return _image_crop_table_parallel(
             table=table,
@@ -1033,6 +1053,7 @@ def image_crop_table_from_joined_chunk(
             segmentation_file_regex=segmentation_file_regex,
             path_kwargs=path_kwargs,
             workers=workers,
+            key_field_names=key_field_names,
         )
 
     image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
@@ -1051,7 +1072,7 @@ def image_crop_table_from_joined_chunk(
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
     )
-    return _rows_to_crop_table(rows, ome_arrow_struct)
+    return _rows_to_crop_table(rows, ome_arrow_struct, key_field_names)
 
 
 # Minimum number of *unique* source images before the source-image ProcessPool
@@ -1176,24 +1197,15 @@ def _collect_source_rows(
 def _rows_to_source_table(
     rows: list[dict[str, Any]],
     ome_arrow_struct: pa.DataType,
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Assemble source-image rows into an Arrow table.
-    """
 
-    key_field_names = sorted(
-        {key for row in rows for key in row.keys()}
-        - {
-            "Metadata_ImageID",
-            "source_image_column",
-            "source_image_file",
-            "label_source_kind",
-            "ome_arrow_image",
-            "ome_arrow_outline",
-            "ome_arrow_mask",
-            "ome_arrow_label",
-        }
-    )
+    ``key_field_names`` is the full chunk's key field set (see
+    :func:`_extract_image_key_field_names`) so empty shard outputs carry the
+    same schema as non-empty siblings and concatenate cleanly.
+    """
 
     if not rows:
         return pa.table(
@@ -1272,13 +1284,15 @@ def _source_shard_worker(
     image_columns: Sequence[str],
     segmentation_file_regex: Optional[Dict[str, str]],
     path_kwargs: Optional[Dict[str, Any]],
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Process one row-shard of a joined chunk for source-image export.
 
     Module-level so it is importable under multiprocessing spawn. Rebuilds the
     file indexes locally to avoid serializing ``CloudPath`` across the process
-    boundary.
+    boundary. ``key_field_names`` is the full chunk's key field set, passed in
+    so empty shards still emit the complete schema.
     """
 
     _, ome_arrow_struct = _require_ome_arrow()
@@ -1299,7 +1313,7 @@ def _source_shard_worker(
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
     )
-    return _rows_to_source_table(rows, ome_arrow_struct)
+    return _rows_to_source_table(rows, ome_arrow_struct, key_field_names)
 
 
 def _source_image_table_parallel(
@@ -1311,13 +1325,16 @@ def _source_image_table_parallel(
     segmentation_file_regex: Optional[Dict[str, str]],
     path_kwargs: Optional[Dict[str, Any]],
     workers: int,
+    key_field_names: Sequence[str],
 ) -> pa.Table:
     """
     Run source-image export across ``workers`` processes and merge results.
 
     Each shard deduplicates internally by ``Metadata_ImageID``; the merged table
     is deduplicated again across shards (first occurrence wins) so an image that
-    appears in more than one shard is exported exactly once.
+    appears in more than one shard is exported exactly once. ``key_field_names``
+    is the full chunk's key field set, passed to shards so empty shards still
+    emit the complete schema.
     """
 
     with tempfile.TemporaryDirectory(prefix="cytotable_source_shards_") as tmpdir:
@@ -1330,8 +1347,12 @@ def _source_image_table_parallel(
             image_columns=list(image_columns),
             segmentation_file_regex=segmentation_file_regex,
             path_kwargs=path_kwargs,
+            key_field_names=list(key_field_names),
         )
-        with ProcessPoolExecutor(max_workers=min(workers, len(shard_paths))) as ex:
+        with ProcessPoolExecutor(
+            max_workers=min(workers, len(shard_paths)),
+            mp_context=multiprocessing.get_context("spawn"),
+        ) as ex:
             shard_tables = list(ex.map(worker, shard_paths))
     merged = pa.concat_tables(shard_tables)
     return _dedup_table_by_first_occurrence(merged, "Metadata_ImageID")
@@ -1380,6 +1401,7 @@ def source_image_table_from_joined_chunk(
 
     workers = _resolve_image_worker_count(crop_workers)
     unique_image_count = _count_unique_source_image_names(data, image_columns)
+    key_field_names = _extract_image_key_field_names(data)
     if workers > 1 and unique_image_count >= _SOURCE_PARALLEL_MIN:
         return _source_image_table_parallel(
             table=table,
@@ -1390,6 +1412,7 @@ def source_image_table_from_joined_chunk(
             segmentation_file_regex=segmentation_file_regex,
             path_kwargs=path_kwargs,
             workers=workers,
+            key_field_names=key_field_names,
         )
 
     image_index = _build_file_index(image_dir, path_kwargs=path_kwargs)
@@ -1407,7 +1430,7 @@ def source_image_table_from_joined_chunk(
         segmentation_file_regex=segmentation_file_regex,
         path_kwargs=path_kwargs,
     )
-    return _rows_to_source_table(rows, ome_arrow_struct)
+    return _rows_to_source_table(rows, ome_arrow_struct, key_field_names)
 
 
 def add_object_id_to_profiles_frame(

--- a/cytotable/warehouse/images.py
+++ b/cytotable/warehouse/images.py
@@ -11,6 +11,7 @@ import pathlib
 import re
 import tempfile
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from functools import partial
 from json import dumps
@@ -22,6 +23,7 @@ import pyarrow as pa
 import pyarrow.parquet as parquet
 from cloudpathlib import AnyPath, CloudPath
 
+from cytotable.exceptions import CytoTableException
 from cytotable.sources import _build_path
 from cytotable.utils import cloud_glob
 
@@ -523,7 +525,9 @@ def _extract_image_key_field_names(data: pd.DataFrame) -> list[str]:
 
     Computed from the full chunk so every shard -- including ones that emit no
     rows -- assembles a table with the same key columns, which is required for
-    ``pa.concat_tables`` to succeed across shards.
+    ``pa.concat_tables`` to succeed across shards. Used for the per-image
+    ``images.source_images`` table, whose rows are keyed per image rather than
+    per object, so object-identity columns are intentionally excluded.
     """
 
     preferred_columns = [
@@ -539,6 +543,53 @@ def _extract_image_key_field_names(data: pd.DataFrame) -> list[str]:
         for column in preferred_columns
         if column in data.columns and not data[column].isna().all()
     )
+
+
+def _extract_crop_key_field_names(data: pd.DataFrame) -> list[str]:
+    """
+    Return the sorted key field names to carry on ``images.image_crops`` rows.
+
+    Mirrors the per-row discovery in :func:`_extract_key_fields`: the preferred
+    image/object-level columns plus any CellProfiler-native object-identity and
+    parent-linkage columns (names ending in ``_Object_Number``,
+    ``_Parent_Cells``, or ``_Parent_Nuclei``) that occur in the chunk. The
+    suffix match is needed because these names are compartment-prefixed (e.g.
+    ``Cells_Number_Object_Number``, ``Cytoplasm_Parent_Nuclei``) and so cannot
+    be enumerated up front; without it they were silently dropped from
+    ``images.image_crops`` for ``cellprofiler_sqlite``-preset data.
+
+    A column is included when at least one row in the chunk carries a non-null
+    value, matching :func:`_extract_key_fields`' row-by-row null omission (and
+    the serial path's previous ``sorted({keys} - {fixed})`` behavior), so the
+    column set matches what the serial path produced.
+
+    Computed from the full chunk so every shard -- including ones that emit no
+    rows -- assembles a table with the same key columns, which is required for
+    ``pa.concat_tables`` to succeed across shards.
+    """
+
+    preferred_columns = [
+        "Metadata_TableNumber",
+        "Metadata_ImageNumber",
+        "Metadata_ObjectNumber",
+        "Image_Metadata_Well",
+        "Image_Metadata_Plate",
+        "Metadata_Well",
+        "Metadata_Plate",
+    ]
+    names = {
+        column
+        for column in preferred_columns
+        if column in data.columns and not data[column].isna().all()
+    }
+    suffixes = ("_Object_Number", "_Parent_Cells", "_Parent_Nuclei")
+    for column in data.columns:
+        column_str = str(column)
+        if column_str in names:
+            continue
+        if column_str.endswith(suffixes) and not data[column].isna().all():
+            names.add(column_str)
+    return sorted(names)
 
 
 def _build_stable_object_id(
@@ -1000,7 +1051,19 @@ def _image_crop_table_parallel(
             max_workers=min(workers, len(shard_paths)),
             mp_context=multiprocessing.get_context("spawn"),
         ) as ex:
-            shard_tables = list(ex.map(worker, shard_paths))
+            try:
+                shard_tables = list(ex.map(worker, shard_paths))
+            except BrokenProcessPool as exc:  # pragma: no cover - spawn guard
+                raise CytoTableException(
+                    "Image-crop worker pool died before completing. The crop "
+                    "workers use the 'spawn' start method, which re-imports the "
+                    "caller's top-level script as __main__ in each worker. If "
+                    "you call convert(...) from a plain script, guard that call "
+                    "with `if __name__ == '__main__':` so workers do not re-run "
+                    "your whole pipeline (notebooks and REPLs are unaffected). "
+                    "As a workaround, set image_crop_workers=1 to use the serial "
+                    "path."
+                ) from exc
     return pa.concat_tables(shard_tables)
 
 
@@ -1023,6 +1086,15 @@ def image_crop_table_from_joined_chunk(
     (``slice_ome_arrow`` over a pyarrow struct) holds the GIL, so threads do not
     help. A threshold (``_CROP_PARALLEL_MIN``) keeps small chunks serial so the
     process-spawn overhead never dominates.
+
+    The parallel path uses the ``spawn`` start method, which re-imports the
+    caller's top-level script as ``__main__`` in each worker. Callers that invoke
+    ``convert(...)`` (or this function) from a plain script must guard that call
+    with ``if __name__ == "__main__":`` so workers do not re-run the whole
+    pipeline; without the guard the pool dies with a ``BrokenProcessPool`` (re
+    -raised here as a :class:`~cytotable.exceptions.CytoTableException` with
+    guidance). Notebooks and REPLs are unaffected. Set ``crop_workers=1`` to
+    bypass the process pool entirely.
     """
 
     _, ome_arrow_struct = _require_ome_arrow()
@@ -1041,7 +1113,7 @@ def image_crop_table_from_joined_chunk(
 
     workers = _resolve_image_worker_count(crop_workers)
     estimated_crops = len(data) * max(1, len(image_columns))
-    key_field_names = _extract_image_key_field_names(data)
+    key_field_names = _extract_crop_key_field_names(data)
     if workers > 1 and estimated_crops >= _CROP_PARALLEL_MIN:
         return _image_crop_table_parallel(
             table=table,
@@ -1353,7 +1425,18 @@ def _source_image_table_parallel(
             max_workers=min(workers, len(shard_paths)),
             mp_context=multiprocessing.get_context("spawn"),
         ) as ex:
-            shard_tables = list(ex.map(worker, shard_paths))
+            try:
+                shard_tables = list(ex.map(worker, shard_paths))
+            except BrokenProcessPool as exc:  # pragma: no cover - spawn guard
+                raise CytoTableException(
+                    "Source-image worker pool died before completing. The image "
+                    "workers use the 'spawn' start method, which re-imports the "
+                    "caller's top-level script as __main__ in each worker. If you "
+                    "call convert(...) from a plain script, guard that call with "
+                    "`if __name__ == '__main__':` so workers do not re-run your "
+                    "whole pipeline (notebooks and REPLs are unaffected). As a "
+                    "workaround, set image_crop_workers=1 to use the serial path."
+                ) from exc
     merged = pa.concat_tables(shard_tables)
     return _dedup_table_by_first_occurrence(merged, "Metadata_ImageID")
 

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -178,6 +178,7 @@ Here, an "image-crop table" means a table where each row stores one cropped sing
 This table stores cropped images as OME-Arrow objects, meaning structured image records that keep image data together with related metadata. The table may also include mask and outline images through :code:`mask_dir`, :code:`outline_dir`, and :code:`segmentation_file_regex`.
 Set :code:`include_source_images=True` to also store full source images in :code:`images.source_images`.
 These image, mask, and outline inputs may be local paths or remote object-storage paths, and they use the same :code:`convert(..., **kwargs)` cloud configuration pattern described above for other CytoTable inputs.
+Image export parallelizes the per-crop work across worker processes automatically; tune the worker count with :code:`image_crop_workers=` (default automatic, set :code:`1` to force serial). See the `image crops tutorial <../tutorials/iceberg_warehouse_with_images.html>`_ for details.
 ```
 
 ## Data Transformations

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -178,7 +178,7 @@ Here, an "image-crop table" means a table where each row stores one cropped sing
 This table stores cropped images as OME-Arrow objects, meaning structured image records that keep image data together with related metadata. The table may also include mask and outline images through :code:`mask_dir`, :code:`outline_dir`, and :code:`segmentation_file_regex`.
 Set :code:`include_source_images=True` to also store full source images in :code:`images.source_images`.
 These image, mask, and outline inputs may be local paths or remote object-storage paths, and they use the same :code:`convert(..., **kwargs)` cloud configuration pattern described above for other CytoTable inputs.
-Image export parallelizes the per-crop work across worker processes automatically; tune the worker count with :code:`image_crop_workers=` (default automatic, set :code:`1` to force serial). See the `image crops tutorial <../tutorials/iceberg_warehouse_with_images.html>`_ for details.
+Image export parallelizes the per-crop work across worker processes automatically; tune the worker count with :code:`image_crop_workers=` (default automatic, set :code:`1` to force serial). See the `image crops tutorial <tutorials/iceberg_warehouse_with_images.md>`_ for details.
 ```
 
 ## Data Transformations

--- a/docs/source/tutorials/iceberg_warehouse_with_images.md
+++ b/docs/source/tutorials/iceberg_warehouse_with_images.md
@@ -163,9 +163,14 @@ convert(
 which is around the sweet spot on a typical multi-core machine. Set it to `0` or
 `1` to force the serial path. Small chunks stay serial automatically, so the
 process pool is only spawned when there is enough work to amortize the startup
-cost. For multi-chunk plates (thousands of images) where CytoTable already
-parallelizes across chunks, lower `image_crop_workers` to avoid oversubscribing
-cores, since each chunk spawns its own worker pool.
+cost.
+
+Note that `image_crop_workers` is *per chunk*. CytoTable also runs chunks
+concurrently through a Parsl thread pool (default 4 threads), so a multi-chunk
+plate can run up to `4 × image_crop_workers` crop processes at once — up to
+`4 × 8 = 32` with the defaults. That oversubscribes a typical 8-core machine, so
+for multi-chunk plates (thousands of images) lower `image_crop_workers` (for
+example `1` or `2`) to keep the total process count near your core count.
 
 ### Calling from a plain script: the `if __name__ == "__main__":` guard
 

--- a/docs/source/tutorials/iceberg_warehouse_with_images.md
+++ b/docs/source/tutorials/iceberg_warehouse_with_images.md
@@ -137,6 +137,36 @@ The same pattern also works with cloud image paths, for example
 `image_dir="s3://example-bucket/images"` plus any needed authentication or
 client configuration arguments passed through `convert(..., **kwargs)`.
 
+## Performance of image export
+
+Cropping one image per measurement row is the dominant cost of image export
+(the per-crop slicing work, not the TIFF read). CytoTable parallelizes this
+work across worker processes automatically — within each chunk, because the
+slice work holds the Python GIL and therefore does not benefit from threads.
+
+Tune the worker count with `image_crop_workers`:
+
+```python
+convert(
+    source_path="./tests/data/cellprofiler/ExampleHuman",
+    source_datatype="csv",
+    dest_path="./example_warehouse_perf",
+    dest_backend="iceberg",
+    dest_datatype="parquet",
+    preset="cellprofiler_csv",
+    image_dir="./images",
+    image_crop_workers=8,  # default: automatic (capped at 8); 0 or 1 = serial
+)
+```
+
+`image_crop_workers=None` (the default) selects an automatic count capped at 8,
+which is around the sweet spot on a typical multi-core machine. Set it to `0` or
+`1` to force the serial path. Small chunks stay serial automatically, so the
+process pool is only spawned when there is enough work to amortize the startup
+cost. For multi-chunk plates (thousands of images) where CytoTable already
+parallelizes across chunks, lower `image_crop_workers` to avoid oversubscribing
+cores, since each chunk spawns its own worker pool.
+
 ## Bounding boxes
 
 CytoTable uses bounding box columns from the joined measurement rows to dynamically crop each image.

--- a/docs/source/tutorials/iceberg_warehouse_with_images.md
+++ b/docs/source/tutorials/iceberg_warehouse_with_images.md
@@ -167,6 +167,39 @@ cost. For multi-chunk plates (thousands of images) where CytoTable already
 parallelizes across chunks, lower `image_crop_workers` to avoid oversubscribing
 cores, since each chunk spawns its own worker pool.
 
+### Calling from a plain script: the `if __name__ == "__main__":` guard
+
+The parallel path starts workers with the `spawn` start method. `spawn` launches
+a fresh Python interpreter for each worker and re-imports the caller's
+top-level script as `__main__` in that worker. If your script calls `convert(...)`
+at module level (outside any guard), every worker re-runs your entire pipeline
+instead of just its crop shard, and the pool dies with a `BrokenProcessPool`
+(CytoTable re-raises this as a `CytoTableException` that points back here).
+
+This only affects plain `.py` scripts. Notebooks and the interactive REPL have
+no `__main__` file to re-import, so they are unaffected.
+
+Guard the call when running from a script:
+
+```python
+from cytotable import convert
+
+if __name__ == "__main__":
+    convert(
+        source_path="./tests/data/cellprofiler/ExampleHuman",
+        source_datatype="csv",
+        dest_path="./example_warehouse_perf",
+        dest_backend="iceberg",
+        dest_datatype="parquet",
+        preset="cellprofiler_csv",
+        image_dir="./images",
+        image_crop_workers=8,
+    )
+```
+
+If you cannot add the guard (or want to sidestep the process pool entirely), set
+`image_crop_workers=1` to use the serial path.
+
 ## Bounding boxes
 
 CytoTable uses bounding box columns from the joined measurement rows to dynamically crop each image.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -231,6 +231,7 @@ def test_convert_routes_to_iceberg(monkeypatch: pytest.MonkeyPatch):
         preset=None,
         drop_null=False,
         parsl_config=None,
+        image_crop_workers=None,
     )
 
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -46,6 +46,8 @@ from cytotable.warehouse.images import (
     _build_file_index,
     _crop_ome_arrow,
     _dedup_table_by_first_occurrence,
+    _extract_crop_key_field_names,
+    _extract_image_key_field_names,
     _find_matching_segmentation_path,
     _require_ome_arrow,
     _strip_null_fields_from_type,
@@ -1135,6 +1137,135 @@ def test_image_crop_parallel_matches_serial(fx_tempdir: str):
     assert _table_to_normalized_pydict(serial, "Metadata_ImageCropID") == (
         _table_to_normalized_pydict(parallel, "Metadata_ImageCropID")
     )
+
+    # Explicitly assert the cropped image payloads themselves are equivalent
+    # between the two paths. The full-table comparison above already includes
+    # ome_arrow_image, but this makes the image-crop equivalence obvious and
+    # pinpoints pixel drift on failure (instead of a whole-table diff). Every
+    # row references a resolvable image with an in-bounds bbox, so no crops are
+    # null; acquisition_datetime is read-time-stamped by ome_arrow, so strip
+    # that non-deterministic field before comparing the struct payloads.
+    serial_sorted = serial.sort_by([("Metadata_ImageCropID", "ascending")])
+    parallel_sorted = parallel.sort_by([("Metadata_ImageCropID", "ascending")])
+    assert serial_sorted["ome_arrow_image"].null_count == 0
+    assert parallel_sorted["ome_arrow_image"].null_count == 0
+    assert _strip_acquisition_datetime(
+        serial_sorted["ome_arrow_image"].to_pylist()
+    ) == _strip_acquisition_datetime(parallel_sorted["ome_arrow_image"].to_pylist())
+
+
+def test_extract_crop_key_field_names_includes_object_columns():
+    """
+    _extract_crop_key_field_names discovers CellProfiler object-identity and
+    parent-linkage columns (suffixes _Object_Number / _Parent_Cells /
+    _Parent_Nuclei) plus Metadata_ObjectNumber, while all-NaN columns are
+    excluded. _extract_image_key_field_names (the source-image path) excludes
+    object-level columns because source images are keyed per image.
+    """
+
+    data = pd.DataFrame(
+        {
+            "Metadata_ImageNumber": [1, 2],
+            "Metadata_ObjectNumber": [1, 2],
+            "Cells_Number_Object_Number": [1, 2],
+            "Cytoplasm_Parent_Nuclei": [1, 2],
+            "Cells_Parent_Nuclei": [1, None],  # not all-null -> included
+            "Nuclei_Number_Object_Number": [None, None],  # all-null -> excluded
+            "Some_Other_Column": [1, 2],
+        }
+    )
+
+    assert set(_extract_crop_key_field_names(data)) == {
+        "Metadata_ImageNumber",
+        "Metadata_ObjectNumber",
+        "Cells_Number_Object_Number",
+        "Cytoplasm_Parent_Nuclei",
+        "Cells_Parent_Nuclei",
+    }
+
+    image_names = set(_extract_image_key_field_names(data))
+    assert image_names == {"Metadata_ImageNumber"}
+    assert not image_names & {
+        "Metadata_ObjectNumber",
+        "Cells_Number_Object_Number",
+        "Cytoplasm_Parent_Nuclei",
+        "Cells_Parent_Nuclei",
+    }
+
+
+@pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")
+def test_image_crop_preserves_object_key_columns(fx_tempdir: str):
+    """
+    Object-identity and parent-linkage columns survive on images.image_crops.
+
+    Regression: the parallel path's key-field allowlist silently dropped
+    CellProfiler-native columns (names ending in _Object_Number, _Parent_Cells,
+    or _Parent_Nuclei) such as Cells_Number_Object_Number and
+    Cytoplasm_Parent_Nuclei. Both the serial and parallel paths must carry them,
+    with matching schemas.
+    """
+
+    tifffile = pytest.importorskip("tifffile")
+
+    image_dir = Path(fx_tempdir) / "images"
+    image_dir.mkdir()
+    tifffile.imwrite(
+        image_dir / "cell.tiff", np.arange(100, dtype=np.uint16).reshape(10, 10)
+    )
+
+    # 40 rows x 2 image columns = 80 crops >= _CROP_PARALLEL_MIN (64).
+    n_rows = 40
+    rows = []
+    for i in range(n_rows):
+        rows.append(
+            {
+                "Metadata_ImageNumber": 1,
+                "Metadata_ObjectNumber": i + 1,
+                "Image_FileName_DNA": "cell.tiff",
+                "Image_FileName_AGP": "cell.tiff",
+                "Cells_AreaShape_BoundingBoxMinimum_X": 1,
+                "Cells_AreaShape_BoundingBoxMaximum_X": 5,
+                "Cells_AreaShape_BoundingBoxMinimum_Y": 1,
+                "Cells_AreaShape_BoundingBoxMaximum_Y": 5,
+                "Cells_Number_Object_Number": i + 1,
+                "Nuclei_Number_Object_Number": i + 1,
+                "Cytoplasm_Number_Object_Number": i + 1,
+                "Cytoplasm_Parent_Cells": i + 1,
+                "Cytoplasm_Parent_Nuclei": i + 1,
+                "Cells_Parent_Nuclei": i + 1,
+            }
+        )
+    chunk_path = Path(fx_tempdir) / "joined_object_keys.parquet"
+    parquet.write_table(
+        pa.Table.from_pandas(pd.DataFrame(rows), preserve_index=False), chunk_path
+    )
+
+    expected_key_columns = {
+        "Metadata_ObjectNumber",
+        "Cells_Number_Object_Number",
+        "Nuclei_Number_Object_Number",
+        "Cytoplasm_Number_Object_Number",
+        "Cytoplasm_Parent_Cells",
+        "Cytoplasm_Parent_Nuclei",
+        "Cells_Parent_Nuclei",
+    }
+
+    serial = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=1
+    )
+    parallel = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=4
+    )
+
+    for table in (serial, parallel):
+        assert expected_key_columns.issubset(set(table.column_names))
+        for col in expected_key_columns:
+            # Carried through as non-null strings (see _rows_to_crop_table).
+            assert table[col].null_count == 0, col
+
+    # Serial and parallel paths produce the same schema and row count.
+    assert set(serial.column_names) == set(parallel.column_names)
+    assert serial.num_rows == parallel.num_rows == n_rows * 2
 
 
 @pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -9,7 +9,7 @@ import re
 from importlib.util import find_spec
 from json import dumps, loads
 from pathlib import Path
-from typing import Optional, cast
+from typing import Any, Optional, cast
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -28,6 +28,7 @@ from cytotable.utils import (
     _default_parsl_config,
     _ensure_thread_executor,
 )
+from cytotable.warehouse import images as images_module
 from cytotable.warehouse.iceberg import (
     _rewrite_join_sql_for_warehouse,
     _validate_iceberg_join_prerequisites,
@@ -44,6 +45,7 @@ from cytotable.warehouse.images import (
     FileIndex,
     _build_file_index,
     _crop_ome_arrow,
+    _dedup_table_by_first_occurrence,
     _find_matching_segmentation_path,
     _require_ome_arrow,
     _strip_null_fields_from_type,
@@ -1036,6 +1038,226 @@ def test_image_crop_table_skips_invalid_bbox_rows(fx_tempdir: str):
     assert crop_table["source_bbox_x_max"].to_pylist() == [7]
     assert crop_table["source_bbox_y_min"].to_pylist() == [2]
     assert crop_table["source_bbox_y_max"].to_pylist() == [8]
+
+
+def _write_image_crop_chunk(
+    chunk_path: Path, image_names: list[str], n_rows: int
+) -> None:
+    """
+    Write a joined chunk with ``n_rows`` rows referencing ``image_names``.
+
+    Each row has two image columns (DNA, AGP) and CellProfiler-style bbox
+    columns kept inside a 10x10 image. Used to exceed ``_CROP_PARALLEL_MIN``.
+    """
+
+    rows = []
+    for i in range(n_rows):
+        name = image_names[i % len(image_names)]
+        x0 = i % 6
+        y0 = (i * 3) % 6
+        rows.append(
+            {
+                "Metadata_ImageNumber": 1,
+                "Metadata_ObjectNumber": i + 1,
+                "Image_FileName_DNA": name,
+                "Image_FileName_AGP": image_names[(i + 1) % len(image_names)],
+                "Cells_AreaShape_BoundingBoxMinimum_X": x0,
+                "Cells_AreaShape_BoundingBoxMaximum_X": x0 + 4,
+                "Cells_AreaShape_BoundingBoxMinimum_Y": y0,
+                "Cells_AreaShape_BoundingBoxMaximum_Y": y0 + 4,
+            }
+        )
+    parquet.write_table(
+        pa.Table.from_pandas(pd.DataFrame(rows), preserve_index=False), chunk_path
+    )
+
+
+def _strip_acquisition_datetime(obj: Any) -> Any:
+    """
+    Recursively drop ``acquisition_datetime`` from OME-Arrow struct payloads.
+
+    ome_arrow stamps this field with the read time on every ``from_tiff`` call,
+    so it is non-deterministic across reads (and across processes). The pixel
+    data and all other fields are deterministic, so removing this field yields a
+    stable value for equality comparisons.
+    """
+
+    if isinstance(obj, dict):
+        return {
+            k: _strip_acquisition_datetime(v)
+            for k, v in obj.items()
+            if k != "acquisition_datetime"
+        }
+    if isinstance(obj, list):
+        return [_strip_acquisition_datetime(v) for v in obj]
+    return obj
+
+
+def _table_to_normalized_pydict(table: pa.Table, sort_key: str) -> dict:
+    """Sort a table by ``sort_key`` and return a deterministic pydict."""
+
+    return _strip_acquisition_datetime(
+        table.sort_by([(sort_key, "ascending")]).to_pydict()
+    )
+
+
+@pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")
+def test_image_crop_parallel_matches_serial(fx_tempdir: str):
+    """
+    The ProcessPool row-shard path produces identical output to the serial path.
+    """
+
+    tifffile = pytest.importorskip("tifffile")
+
+    image_dir = Path(fx_tempdir) / "images"
+    image_dir.mkdir()
+    tifffile.imwrite(
+        image_dir / "cell.tiff", np.arange(100, dtype=np.uint16).reshape(10, 10)
+    )
+
+    # 40 rows x 2 image columns = 80 crops >= _CROP_PARALLEL_MIN (64).
+    chunk_path = Path(fx_tempdir) / "joined_parallel.parquet"
+    _write_image_crop_chunk(chunk_path, ["cell.tiff"], 40)
+
+    serial = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=1
+    )
+    parallel = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=4
+    )
+
+    assert serial.num_rows == 80
+    assert parallel.num_rows == 80
+    # Same columns/schema.
+    assert serial.column_names == parallel.column_names
+    # Same content, compared in a stable order (acquisition_datetime excluded
+    # because ome_arrow stamps it with the read time).
+    assert _table_to_normalized_pydict(serial, "Metadata_ImageCropID") == (
+        _table_to_normalized_pydict(parallel, "Metadata_ImageCropID")
+    )
+
+
+@pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")
+def test_image_crop_parallel_is_deterministic(fx_tempdir: str):
+    """
+    Repeated parallel runs produce identical output.
+    """
+
+    tifffile = pytest.importorskip("tifffile")
+
+    image_dir = Path(fx_tempdir) / "images"
+    image_dir.mkdir()
+    tifffile.imwrite(
+        image_dir / "cell.tiff", np.arange(100, dtype=np.uint16).reshape(10, 10)
+    )
+
+    chunk_path = Path(fx_tempdir) / "joined_deterministic.parquet"
+    _write_image_crop_chunk(chunk_path, ["cell.tiff"], 40)
+
+    first = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=4
+    )
+    second = image_crop_table_from_joined_chunk(
+        chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=4
+    )
+    assert _table_to_normalized_pydict(first, "Metadata_ImageCropID") == (
+        _table_to_normalized_pydict(second, "Metadata_ImageCropID")
+    )
+
+
+@pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")
+def test_image_crop_below_threshold_stays_serial(fx_tempdir: str):
+    """
+    Small chunks (below _CROP_PARALLEL_MIN) do not spawn a process pool.
+    """
+
+    tifffile = pytest.importorskip("tifffile")
+
+    image_dir = Path(fx_tempdir) / "images"
+    image_dir.mkdir()
+    tifffile.imwrite(
+        image_dir / "cell.tiff", np.arange(100, dtype=np.uint16).reshape(10, 10)
+    )
+
+    # 1 row x 2 image columns = 2 crops, below the threshold.
+    chunk_path = Path(fx_tempdir) / "joined_small.parquet"
+    _write_image_crop_chunk(chunk_path, ["cell.tiff"], 1)
+
+    with patch.object(images_module, "ProcessPoolExecutor") as mock_pool:
+        crop_table = image_crop_table_from_joined_chunk(
+            chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=4
+        )
+    mock_pool.assert_not_called()
+    assert crop_table.num_rows == 2
+
+
+def test_dedup_table_by_first_occurrence():
+    """
+    _dedup_table_by_first_occurrence keeps the first row per key and preserves order.
+    """
+
+    table = pa.table(
+        {
+            "Metadata_ImageID": ["a", "b", "a", "c", "b", None],
+            "payload": pa.array(
+                [
+                    {"x": 1},
+                    {"x": 2},
+                    {"x": 3},
+                    {"x": 4},
+                    {"x": 5},
+                    {"x": 6},
+                ],
+                type=pa.struct([pa.field("x", pa.int64())]),
+            ),
+        }
+    )
+
+    deduped = _dedup_table_by_first_occurrence(table, "Metadata_ImageID")
+    assert deduped.column("Metadata_ImageID").to_pylist() == ["a", "b", "c", None]
+    assert deduped.column("payload").to_pylist() == [
+        {"x": 1},
+        {"x": 2},
+        {"x": 4},
+        {"x": 6},
+    ]
+
+
+@pytest.mark.skipif(find_spec("ome_arrow") is None, reason="ome-arrow not installed")
+def test_source_image_parallel_dedup_matches_serial(fx_tempdir: str):
+    """
+    The source-image parallel path deduplicates across shards and matches serial.
+    """
+
+    tifffile = pytest.importorskip("tifffile")
+
+    image_dir = Path(fx_tempdir) / "images"
+    image_dir.mkdir()
+    for name in ("a.tiff", "b.tiff"):
+        tifffile.imwrite(
+            image_dir / name, np.arange(100, dtype=np.uint16).reshape(10, 10)
+        )
+
+    chunk_path = Path(fx_tempdir) / "joined_source_parallel.parquet"
+    _write_image_crop_chunk(chunk_path, ["a.tiff", "b.tiff"], 30)
+
+    # Lower the unique-image threshold so the 2-image chunk takes the parallel path.
+    with patch.object(images_module, "_SOURCE_PARALLEL_MIN", 1):
+        serial = source_image_table_from_joined_chunk(
+            chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=1
+        )
+        parallel = source_image_table_from_joined_chunk(
+            chunk_path=str(chunk_path), image_dir=str(image_dir), crop_workers=2
+        )
+
+    serial_ids = serial["Metadata_ImageID"].to_pylist()
+    parallel_ids = parallel["Metadata_ImageID"].to_pylist()
+    assert len(serial_ids) == len(set(serial_ids))
+    assert len(parallel_ids) == len(set(parallel_ids))
+    assert serial.num_rows == parallel.num_rows
+    assert _table_to_normalized_pydict(serial, "Metadata_ImageID") == (
+        _table_to_normalized_pydict(parallel, "Metadata_ImageID")
+    )
 
 
 @pytest.mark.skipif(find_spec("pyiceberg") is None, reason="pyiceberg not installed")

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -1259,6 +1259,65 @@ def test_source_image_parallel_dedup_matches_serial(fx_tempdir: str):
         _table_to_normalized_pydict(parallel, "Metadata_ImageID")
     )
 
+    # Empty-shard coverage: a shard whose rows are all-unresolvable yields no
+    # rows, and crop_workers exceeding the row count produces empty trailing
+    # shards. Both cases must still emit the full schema so concat across
+    # shards succeeds and the parallel output matches serial.
+    empty_chunk = Path(fx_tempdir) / "joined_source_empty_shards.parquet"
+    empty_rows = []
+    # rows 0-1 reference a resolvable image in both columns; rows 2-3 reference
+    # only an unresolvable image, so their shard contributes zero rows.
+    for i in range(2):
+        empty_rows.append(
+            {
+                "Metadata_ImageNumber": 1,
+                "Metadata_ObjectNumber": i + 1,
+                "Image_FileName_DNA": "a.tiff",
+                "Image_FileName_AGP": "a.tiff",
+                "Cells_AreaShape_BoundingBoxMinimum_X": 0,
+                "Cells_AreaShape_BoundingBoxMaximum_X": 4,
+                "Cells_AreaShape_BoundingBoxMinimum_Y": 0,
+                "Cells_AreaShape_BoundingBoxMaximum_Y": 4,
+            }
+        )
+    for i in range(2):
+        empty_rows.append(
+            {
+                "Metadata_ImageNumber": 1,
+                "Metadata_ObjectNumber": i + 3,
+                "Image_FileName_DNA": "missing.tiff",
+                "Image_FileName_AGP": "missing.tiff",
+                "Cells_AreaShape_BoundingBoxMinimum_X": 0,
+                "Cells_AreaShape_BoundingBoxMaximum_X": 4,
+                "Cells_AreaShape_BoundingBoxMinimum_Y": 0,
+                "Cells_AreaShape_BoundingBoxMaximum_Y": 4,
+            }
+        )
+    parquet.write_table(
+        pa.Table.from_pandas(pd.DataFrame(empty_rows), preserve_index=False),
+        empty_chunk,
+    )
+
+    with patch.object(images_module, "_SOURCE_PARALLEL_MIN", 1):
+        serial_empty = source_image_table_from_joined_chunk(
+            chunk_path=str(empty_chunk), image_dir=str(image_dir), crop_workers=1
+        )
+        # crop_workers=8 >> 4 rows -> empty trailing shards; rows 2-3 form a
+        # 0-output shard.
+        parallel_empty = source_image_table_from_joined_chunk(
+            chunk_path=str(empty_chunk), image_dir=str(image_dir), crop_workers=8
+        )
+
+    assert serial_empty.schema == parallel_empty.schema
+    assert serial_empty.num_rows == parallel_empty.num_rows
+    empty_parallel_ids = parallel_empty["Metadata_ImageID"].to_pylist()
+    assert len(empty_parallel_ids) == len(set(empty_parallel_ids))
+    assert _table_to_normalized_pydict(serial_empty, "Metadata_ImageID") == (
+        _table_to_normalized_pydict(parallel_empty, "Metadata_ImageID")
+    )
+    # Only the resolvable image contributes rows (one per image column).
+    assert serial_empty.num_rows == 2
+
 
 @pytest.mark.skipif(find_spec("pyiceberg") is None, reason="pyiceberg not installed")
 def test_write_iceberg_warehouse_writes_source_images_when_requested(


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

Image export is much faster now. Crop work runs across multiple worker
processes automatically (~8 by default), cutting a ~17 min runs from ExampleHuman to a few
minutes. Tunable via `image_crop_workers`; small runs are unchanged.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image cropping and source-image exports now support configurable parallel processing.
  * Added the `image_crop_workers` option to conversion and Iceberg export workflows.
  * Automatic worker selection is available by default, while small workloads can run serially.
  * Output ordering, schema consistency, and source-image deduplication are preserved.

* **Documentation**
  * Added guidance on performance tuning, worker settings, serial execution, process spawning, and avoiding CPU oversubscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->