### PR TITLE
Avoid parsl executor contention

### DIFF
--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -96,9 +96,9 @@ def _default_parsl_config():
 
     Only a single executor (HighThroughputExecutor) is included by default.
     Use of Parsl's ThreadPoolExecutor may result in unfreed memory within
-    certain systems because of Apache Arrow's memory allocators, so it is
-    added on-demand (see _ensure_thread_executor) only for workflows -- such
-    as Iceberg image-crop export -- that specifically require it.
+    certain systems because of Apache Arrow's memory allocators, so
+    _ensure_thread_executor adds it only for workflows -- such as Iceberg
+    image-crop export -- that specifically require it.
     """
     return Config(
         executors=[

--- a/cytotable/utils.py
+++ b/cytotable/utils.py
@@ -93,15 +93,17 @@ def _parsl_loaded() -> bool:
 def _default_parsl_config():
     """
     Return a default Parsl configuration for use with CytoTable.
+
+    Only a single executor (HighThroughputExecutor) is included by default.
+    Use of Parsl's ThreadPoolExecutor may result in unfreed memory within
+    certain systems because of Apache Arrow's memory allocators, so it is
+    added on-demand (see _ensure_thread_executor) only for workflows -- such
+    as Iceberg image-crop export -- that specifically require it.
     """
     return Config(
         executors=[
             HighThroughputExecutor(
                 label="htex_default_for_cytotable",
-            ),
-            ParslThreadPoolExecutor(
-                label=CYTOTABLE_THREAD_EXECUTOR_LABEL,
-                max_threads=4,
             ),
         ]
     )

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -82,13 +82,17 @@ def test_ensure_thread_executor_does_not_duplicate():
     assert len(matching) == 1
 
 
-def test_default_parsl_config_includes_thread_executor():
+def test_default_parsl_config_has_single_executor():
     """
-    _default_parsl_config always includes the cytotable thread executor.
+    _default_parsl_config only includes a single executor by default;
+    the cytotable thread executor is added on-demand via
+    _ensure_thread_executor for workflows that need it (e.g. Iceberg
+    image-crop export).
     """
     cfg = _default_parsl_config()
     labels = {e.label for e in cfg.executors}
-    assert CYTOTABLE_THREAD_EXECUTOR_LABEL in labels
+    assert len(cfg.executors) == 1
+    assert CYTOTABLE_THREAD_EXECUTOR_LABEL not in labels
 
 
 def test_rewrite_join_sql_for_warehouse():

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -85,9 +85,8 @@ def test_ensure_thread_executor_does_not_duplicate():
 def test_default_parsl_config_has_single_executor():
     """
     _default_parsl_config only includes a single HighThroughputExecutor by
-    default; the cytotable thread executor is added on-demand via
-    _ensure_thread_executor for workflows that need it (e.g. Iceberg
-    image-crop export).
+    default; _ensure_thread_executor adds the cytotable thread executor
+    only for workflows that need it (e.g. Iceberg image-crop export).
     """
     cfg = _default_parsl_config()
     assert len(cfg.executors) == 1

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -18,7 +18,7 @@ import pyarrow as pa
 import pytest
 from duckdb import IOException as DuckDBIOException
 from parsl.config import Config
-from parsl.executors import ThreadPoolExecutor
+from parsl.executors import HighThroughputExecutor, ThreadPoolExecutor
 from pyarrow import parquet
 
 from cytotable.exceptions import CytoTableException
@@ -84,15 +84,21 @@ def test_ensure_thread_executor_does_not_duplicate():
 
 def test_default_parsl_config_has_single_executor():
     """
-    _default_parsl_config only includes a single executor by default;
-    the cytotable thread executor is added on-demand via
+    _default_parsl_config only includes a single HighThroughputExecutor by
+    default; the cytotable thread executor is added on-demand via
     _ensure_thread_executor for workflows that need it (e.g. Iceberg
     image-crop export).
     """
     cfg = _default_parsl_config()
-    labels = {e.label for e in cfg.executors}
     assert len(cfg.executors) == 1
-    assert CYTOTABLE_THREAD_EXECUTOR_LABEL not in labels
+    default_executor = cfg.executors[0]
+    assert isinstance(default_executor, HighThroughputExecutor)
+    assert default_executor.label == "htex_default_for_cytotable"
+
+    result = _ensure_thread_executor(cfg)
+    assert len(result.executors) == 2
+    assert result.executors[0] is default_executor
+    assert result.executors[1].label == CYTOTABLE_THREAD_EXECUTOR_LABEL
 
 
 def test_rewrite_join_sql_for_warehouse():


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR addresses parsl executor contention when using the default executor configuration. I see this as a rough patch, with a future scope looking towards alternative and simplified executors (like joblib.parallel). 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Clarified that the default execution configuration uses a single high-throughput executor.
  * The thread-based executor is added only for workflows that require it, while existing default behavior remains unchanged.

* **Documentation**
  * Updated configuration documentation to explain when the thread-based executor is enabled.

* **Tests**
  * Expanded configuration checks to verify the default executor and on-demand thread executor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->